### PR TITLE
Track modplayer Rust workspace as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Modplayer/modplayer"]
+	path = Modplayer/modplayer
+	url = https://github.com/Gil-AdB/modplayer.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ Default build type is `Release`; override with `-DCMAKE_BUILD_TYPE=Debug`. `CMAK
 Prerequisites:
 
 - **SDL2** discovered via `find_package(SDL2)`. On macOS: `brew install sdl2`.
-- **Rust toolchain** (`cargo` on PATH) — CMake invokes `cargo build` on the sibling `modplayer-2` workspace automatically.
-- **`modplayer-2` checked out next to this repo** at `../modplayer-2` (override with `-DMODPLAYER2_DIR=/path`). `Modplayer/CMakeLists.txt` fails loudly if it's missing.
+- **Rust toolchain** (`cargo` on PATH) — CMake invokes `cargo build` on the modplayer workspace automatically.
+- **Submodules** — the Rust workspace lives at `Modplayer/modplayer` as a submodule. Clone with `--recurse-submodules` or run `git submodule update --init --recursive` after checkout. Override with `-DMODPLAYER2_DIR=/path` to point at an external checkout (e.g. for cross-repo development).
 
 Stale/obsolete build trees that may still be on disk from pre-Tier-1 work (`CMake/`, `cmake-build-*`, `build.local/`) are gitignored — delete them freely.
 

--- a/Modplayer/CMakeLists.txt
+++ b/Modplayer/CMakeLists.txt
@@ -1,15 +1,17 @@
 set(PROJECT_NAME Modplayer)
 
-# The heavy lifting is in a sibling Rust workspace. Default to ../modplayer-2
-# (relative to the revival repo root); override with -DMODPLAYER2_DIR=... .
-set(MODPLAYER2_DIR "${CMAKE_SOURCE_DIR}/../modplayer-2" CACHE PATH
+# The heavy lifting is in a Rust workspace tracked as a git submodule at
+# Modplayer/modplayer-2. Override with -DMODPLAYER2_DIR=... to point at a
+# sibling checkout instead (useful for cross-repo development).
+set(MODPLAYER2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/modplayer" CACHE PATH
     "Path to the modplayer-2 Rust workspace")
 
 if(NOT EXISTS "${MODPLAYER2_DIR}/Cargo.toml")
     message(FATAL_ERROR
         "modplayer-2 not found at '${MODPLAYER2_DIR}'.\n"
-        "Clone https://<...>/modplayer-2 next to this repo or pass "
-        "-DMODPLAYER2_DIR=/path/to/modplayer-2.")
+        "Run `git submodule update --init --recursive` from the repo root, "
+        "or pass -DMODPLAYER2_DIR=/path/to/modplayer-2 to point at a sibling "
+        "checkout.")
 endif()
 
 find_program(CARGO_EXECUTABLE cargo REQUIRED)
@@ -28,7 +30,10 @@ set(_modplayer_rust_lib
 
 add_custom_command(
     OUTPUT "${_modplayer_rust_lib}"
-    COMMAND "${CARGO_EXECUTABLE}" build ${_cargo_profile_flag} --package modplayer-lib
+    # CMAKE_POLICY_VERSION_MINIMUM=3.5 lets the vendored sdl2-sys build under
+    # CMake >= 4.0, which dropped compatibility with its older cmake_minimum_required.
+    COMMAND ${CMAKE_COMMAND} -E env CMAKE_POLICY_VERSION_MINIMUM=3.5
+            "${CARGO_EXECUTABLE}" build ${_cargo_profile_flag} --package modplayer-lib
     WORKING_DIRECTORY "${MODPLAYER2_DIR}"
     COMMENT "Building modplayer-2 (Rust, ${_cargo_profile_dir})"
     USES_TERMINAL)


### PR DESCRIPTION
## Summary

- Adds `Modplayer/modplayer` as a git submodule pointing at `https://github.com/Gil-AdB/modplayer.git`, pinned to the current upstream master (`cc4bff4`). This replaces the \"clone the other repo next to revival\" convention with a tracked reference.
- `Modplayer/CMakeLists.txt`'s `MODPLAYER2_DIR` default now points at the submodule path (`\${CMAKE_CURRENT_SOURCE_DIR}/modplayer`); the variable is still a cache path, so `-DMODPLAYER2_DIR=/somewhere/else` continues to work for cross-repo workflows.
- The cargo custom-command now runs with `CMAKE_POLICY_VERSION_MINIMUM=3.5` so the vendored `sdl2-sys`'s bundled SDL2 sources configure under CMake 4.x (which dropped < 3.5 compatibility).
- `CLAUDE.md` prerequisites updated to mention `git submodule update --init --recursive`.

## Test plan

- [x] `rm -rf build && cmake -S . -B build -G Ninja && cmake --build build` — clean build with fresh submodule clone on macOS arm64 + CMake 4.3.1
- [ ] Fresh checkout sanity: `git clone --recurse-submodules … && cmake -S . -B build -G Ninja && cmake --build build` on a clean machine
- [ ] `cd Runtime && ./DEMO` — verify music loads and plays (Modplayer is the only thing this PR touches at runtime)