### PR TITLE
Replace deprecated sprintf with snprintf

### DIFF
--- a/DEMO/CITY.CPP
+++ b/DEMO/CITY.CPP
@@ -2057,38 +2057,38 @@ void Run_City()
 			if (timerIndex == 20)
 			{
 				timerIndex = 0;
-				sprintf(MSGStr, "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
 			}
 			else {
-				sprintf(MSGStr, "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
 			}
 			scroll = OutTextXY(VPage, 0, scroll, MSGStr, 255);
 
-			sprintf(MSGStr, "%f frame", CurFrame);
+			snprintf(MSGStr, sizeof(MSGStr), "%f frame", CurFrame);
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-			sprintf(MSGStr, "%.3lfM pixels/frame", (FillerPixelcount / (1000000.0 * numFrames)));
+			snprintf(MSGStr, sizeof(MSGStr), "%.3lfM pixels/frame", (FillerPixelcount / (1000000.0 * numFrames)));
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-			sprintf(MSGStr, "%.3lfM pixels/second", (FillerPixelcount / 1000000.0 * 100.0 / Profiler[PROF_RNDR]));
+			snprintf(MSGStr, sizeof(MSGStr), "%.3lfM pixels/second", (FillerPixelcount / 1000000.0 * 100.0 / Profiler[PROF_RNDR]));
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-			sprintf(MSGStr, "%d polys/frame", (int32_t)(g_renderedPolys / numFrames));
+			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame", (int32_t)(g_renderedPolys / numFrames));
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 			//		numDropsRendered=0;
-			//		sprintf(MSGStr, "%d raindrops" , (int32_t)(numDropsRendered) );
+			//		snprintf(MSGStr, sizeof(MSGStr), "%d raindrops" , (int32_t)(numDropsRendered) );
 			//		OutTextXY(VPage,0,60,MSGStr,255);
 
 			//		FModGetModuleInfo(mmi);
-			//		sprintf(MSGStr, "Order: %d, Row: %d", mmi.Order, mmi.Row);
+			//		snprintf(MSGStr, sizeof(MSGStr), "Order: %d, Row: %d", mmi.Order, mmi.Row);
 			//		OutTextXY(VPage,0,15,MSGStr,255);
-			//		sprintf(MSGStr, "%dK pixels/second" , (int32_t)(FillerPixelcount/1000.0 * 100.0 / Timer));
+			//		snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second" , (int32_t)(FillerPixelcount/1000.0 * 100.0 / Timer));
 			//		OutTextXY(VPage,0,30,MSGStr,255);
 			//		PROFILER: display stats		
 			for (i = 0; i < PROF_NUM; i++)
 			{
-				sprintf(MSGStr, "%s %3.1fms (%3.1f%%)", ProfNames[i], ProfSample[i], ProfPerc[i]);
+				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)", ProfNames[i], ProfSample[i], ProfPerc[i]);
 				scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 			}
 
-			sprintf(MSGStr, "TOTL %3.1fms", ProfSum * 10.0 / numFrames);
+			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms", ProfSum * 10.0 / numFrames);
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 
 		}

--- a/DEMO/CRASH.CPP
+++ b/DEMO/CRASH.CPP
@@ -95,11 +95,11 @@ void Run_Crash()
 		Render();
 
 		dword scroll = 0;
-		sprintf(MSGStr, "g_FrameTime %d", g_FrameTime);
+		snprintf(MSGStr, sizeof(MSGStr), "g_FrameTime %d", g_FrameTime);
 		scroll += OutTextXY(VPage, 0, scroll, MSGStr, 255);
-		sprintf(MSGStr, "CrPartTime %d", CrPartTime);
+		snprintf(MSGStr, sizeof(MSGStr), "CrPartTime %d", CrPartTime);
 		scroll += OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-		sprintf(MSGStr, "Frame %f/%f", CurFrame, CrashSc->EndFrame);
+		snprintf(MSGStr, sizeof(MSGStr), "Frame %f/%f", CurFrame, CrashSc->EndFrame);
 		scroll += OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 
 #ifdef _C_WATCOM

--- a/DEMO/Config.cpp
+++ b/DEMO/Config.cpp
@@ -27,7 +27,7 @@ int32_t CFGInteger::toInteger()
 char *CFGInteger::toString()
 {
 	char buffer[128];
-	sprintf(buffer, "%d", _value);
+	snprintf(buffer, sizeof(buffer), "%d", _value);
 	return fld_strdup(buffer);
 }
 

--- a/DEMO/FOUNTAIN.CPP
+++ b/DEMO/FOUNTAIN.CPP
@@ -1970,7 +1970,7 @@ void Run_Fountain()
 		Profiler[PROF_RNDR] -= Timer;		
 		Render();
 
-//		sprintf(MSGStr,"Rendered %d Polys,%d Omnis and %d pcls.\n",CPolys,COmnies,CPcls);
+//		snprintf(MSGStr, sizeof(MSGStr),"Rendered %d Polys,%d Omnis and %d pcls.\n",CPolys,COmnies,CPcls);
 //		OutTextXY(VPage,0,0,MSGStr,64);
 
 		if (Rsv_LState)
@@ -2011,28 +2011,28 @@ void Run_Fountain()
 			if (timerIndex==20) 
 			{
 				timerIndex = 0;
-				sprintf(MSGStr,"%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]) );
 			} else {
-				sprintf(MSGStr,"%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]) );
 			}
 			scroll = OutTextXY(VPage,0,0,MSGStr,255);
-			sprintf(MSGStr,"%d outer pcls", g_numPcls);
-			sprintf(MSGStr, "%dK pixels/frame" , (int32_t)(FillerPixelcount/(1000.0*numFrames)));
+			snprintf(MSGStr, sizeof(MSGStr),"%d outer pcls", g_numPcls);
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/frame" , (int32_t)(FillerPixelcount/(1000.0*numFrames)));
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
-			sprintf(MSGStr, "%dK pixels/second" , (int32_t)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second" , (int32_t)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 
-			sprintf(MSGStr, "%d polys/frame" , (int32_t)(g_renderedPolys / numFrames) );
+			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame" , (int32_t)(g_renderedPolys / numFrames) );
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 
 	//		PROFILER: display stats
 			for(i=0; i<PROF_NUM; i++)
 			{
-				sprintf(MSGStr, "%s %3.1fms (%3.1f%%)" , ProfNames[i], ProfSample[i], ProfPerc[i]);
+				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)" , ProfNames[i], ProfSample[i], ProfPerc[i]);
 				scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 			}
 
-			sprintf(MSGStr, "TOTL %3.1fms" , ProfSum*10.0/ numFrames);
+			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms" , ProfSum*10.0/ numFrames);
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 		}
 		Profiler[PROF_FLIP] -= Timer;		

--- a/DEMO/FillerTest.cpp
+++ b/DEMO/FillerTest.cpp
@@ -1282,14 +1282,14 @@ void FillerTest()
 		if (timerIndex == 20)
 		{
 			timerIndex = 0;
-			sprintf(MSGStr, "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
+			snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
 		}
 		else {
-			sprintf(MSGStr, "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
+			snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
 		}
 		dword scroll = OutTextXY(VPage, 0, 0, MSGStr, 255);
 
-		sprintf(MSGStr, "%f frame", CurFrame);
+		snprintf(MSGStr, sizeof(MSGStr), "%f frame", CurFrame);
 		scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 
 		memcpy(MainSurf->Data, g_gbuffer->txtr.data(), XRes * YRes * 4);

--- a/DEMO/GREETS.CPP
+++ b/DEMO/GREETS.CPP
@@ -564,34 +564,34 @@ void Run_Greets()
 			if (timerIndex==20) 
 			{
 				timerIndex = 0;
-				sprintf(MSGStr,"%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]) );
 			} else {
-				sprintf(MSGStr,"%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]) );
 			}
 			dword scroll = 0;
 			scroll = OutTextXY(VPage, 0, 0, MSGStr, 255);
-			sprintf(MSGStr, "Frame %f", CurFrame);
+			snprintf(MSGStr, sizeof(MSGStr), "Frame %f", CurFrame);
 			scroll = OutTextXY(VPage,0, scroll+15,MSGStr,255);
-			sprintf(MSGStr, "%d polys/frame", (int)(g_renderedPolys / numFrames));
+			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame", (int)(g_renderedPolys / numFrames));
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-			sprintf(MSGStr, "%dK pixels/frame" , (int)(FillerPixelcount/(1000.0*numFrames)));
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/frame" , (int)(FillerPixelcount/(1000.0*numFrames)));
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
-			sprintf(MSGStr, "%dK pixels/second" , (int)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second" , (int)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 
 	//		PROFILER: display stats	
 			for(i=0; i<PROF_NUM; i++)
 			{
-				sprintf(MSGStr, "%s %3.1fms (%3.1f%%)" , ProfNames[i], ProfSample[i], ProfPerc[i]);
+				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)" , ProfNames[i], ProfSample[i], ProfPerc[i]);
 				scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 			}
 
-			sprintf(MSGStr, "TOTL %3.1fms" , ProfSum*10.0/ numFrames);
+			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms" , ProfSum*10.0/ numFrames);
 			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
 
-	//		sprintf(MSGStr, "%d percent Z-rejection", (int32_t) ( (float)zReject*100.0/ (zReject+zPass) ));
+	//		snprintf(MSGStr, sizeof(MSGStr), "%d percent Z-rejection", (int32_t) ( (float)zReject*100.0/ (zReject+zPass) ));
 	//		OutTextXY(VPage,0,45,MSGStr,255);
-	//		sprintf(MSGStr, "%d polys/frame" , (int32_t)(g_renderedPolys / numFrames) );
+	//		snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame" , (int32_t)(g_renderedPolys / numFrames) );
 	//		OutTextXY(VPage,0,45,MSGStr,255);
 			// display messages.
 	/*		int32_t I, Y = -15;

--- a/DEMO/Glat.cpp
+++ b/DEMO/Glat.cpp
@@ -620,15 +620,15 @@ void Run_Glato(void)
 				if (timerIndex == 20)
 				{
 					timerIndex = 0;
-					sprintf(MSGStr, "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
+					snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
 				}
 				else {
-					sprintf(MSGStr, "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
+					snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
 				}
 			}
 
 			if (skip) {
-				sprintf(MSGStr, "%f FPS", (float)(tm - TTrd));
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", (float)(tm - TTrd));
 			}
 
 			OutTextXY(FinalPage,0,0,MSGStr,255, xres, yres);

--- a/DEMO/ImageCompression.cpp
+++ b/DEMO/ImageCompression.cpp
@@ -697,7 +697,7 @@ void ImageCompressionTestCode()
 	// #pixels*timer resolution*#passes / time taken
 	float pixelsPerSecond = float(I.x*I.y)*100.0f*numPasses / float(timeTaken);
 	char str[128];
-	sprintf(str, "%f pixels per second\n", pixelsPerSecond);
+	snprintf(str, sizeof(str), "%f pixels per second\n", pixelsPerSecond);
 //	OutputDebugString(str);
 
 

--- a/FDS/FILLERS/IXTGZ.cpp
+++ b/FDS/FILLERS/IXTGZ.cpp
@@ -1075,7 +1075,7 @@ void IX_Prefiller_TGZM(Face* F, Vertex **V, dword numVerts, dword miplevel)
 		for(i=0; i<numVerts; i++)
 		{
 #ifdef TRACE_OBJECTS
-			sprintf(MSGStr, "%f, %f, %x", V[i]->PX, V[i]->PY, V[i]->i);
+			snprintf(MSGStr, sizeof(MSGStr), "%f, %f, %x", V[i]->PX, V[i]->PY, V[i]->i);
 			//OutTextXY(VPage, Fist(V[i]->PX), Fist(V[i]->PY), MSGStr, 255);
 			DebugStrs.emplace_back(Fist(V[i]->PX), Fist(V[i]->PY) + (V[i]->i >> 4) * 15, MSGStr);
 #endif

--- a/FDS/RENDER/RENDER.CPP
+++ b/FDS/RENDER/RENDER.CPP
@@ -2073,31 +2073,31 @@ Away:Tot = Timer-TTrd;
 			 }
 		 }
 #ifdef RUNTIME_INFO_L1
-		 sprintf(Str,"Time = %d , Frame = %5.1f",Timer.load(), CurFrame);
+		 snprintf(Str, 80,"Time = %d , Frame = %5.1f",Timer.load(), CurFrame);
 		 Y = OutTextXY(VPage,0,Y+15,Str,64);
-		 sprintf(Str,"Inst. FPS = %3.2f (%3.2f)",FPS,100.0*(float)Frames/(float)Timer);
+		 snprintf(Str, 80,"Inst. FPS = %3.2f (%3.2f)",FPS,100.0*(float)Frames/(float)Timer);
 		 Y = OutTextXY(VPage,0,Y+15,Str,64);
 #endif
 #ifdef RUNTIME_INFO_L2
-		 //    sprintf(Str,"Active Camera = %s",View->Name);
+		 //    snprintf(Str, 80,"Active Camera = %s",View->Name);
 		 //    Y = OutTextXY(VPage,0,Y+15,Str,64);
 		 //    if (Tot)
 		 //		{
-		 //			sprintf(Str,"Perf. Distribution: xForm=%d%%,P.Knmtx=%d%%,FList=%d%%,Light=%d%%,\nRender=%d%%",(Par1-TTrd)*100/Tot,(Par2-Par1)*100/Tot,(Par3-Par2)*100/Tot,(Par4-Par3)*100/Tot,(Par5-Par4)*100/Tot);
+		 //			snprintf(Str, 80,"Perf. Distribution: xForm=%d%%,P.Knmtx=%d%%,FList=%d%%,Light=%d%%,\nRender=%d%%",(Par1-TTrd)*100/Tot,(Par2-Par1)*100/Tot,(Par3-Par2)*100/Tot,(Par4-Par3)*100/Tot,(Par5-Par4)*100/Tot);
 		 //			Y = OutTextXY(VPage,0,Y+15,Str,64);
 		 //		}
-		 //    sprintf(Str,"Dyn. Kinematics: p(%4.2f,%4.2f,%4.2f),v(%1.4f,%1.4f,%1.4f) r(%1.4f,%1.4f,%1.4f)",FC.ISource.x,FC.ISource.y,FC.ISource.z,FV.x,FV.y,FV.z,FT.x,FT.y,FT.z);
+		 //    snprintf(Str, 80,"Dyn. Kinematics: p(%4.2f,%4.2f,%4.2f),v(%1.4f,%1.4f,%1.4f) r(%1.4f,%1.4f,%1.4f)",FC.ISource.x,FC.ISource.y,FC.ISource.z,FV.x,FV.y,FV.z,FT.x,FT.y,FT.z);
 		 //    Y = OutTextXY(VPage,0,Y+15,Str,64);
-		 sprintf(Str,"Average Polys/Frame: %5.1f (%3.1f%%)",(float)RenderedPolys/(float)Frames,100.0*(float)CPolys/(float)Polys);
+		 snprintf(Str, 80,"Average Polys/Frame: %5.1f (%3.1f%%)",(float)RenderedPolys/(float)Frames,100.0*(float)CPolys/(float)Polys);
 		 Y = OutTextXY(VPage,0,Y+15,Str,64);
 		 int32_t GTP = 0,GTPP = 0;
 		 for(TriMesh *Tri = Sc->TriMeshHead;Tri;Tri = Tri->Next)
 			 if (!(Tri->Flags&Tri_Invisible)) {GTP++; GTPP += Tri->FIndex;}
-			 sprintf(Str,"%d Triangle Meshes totalling in %d Faces",GTP,GTPP);
+			 snprintf(Str, 80,"%d Triangle Meshes totalling in %d Faces",GTP,GTPP);
 			 Y = OutTextXY(VPage,0,Y+15,Str,64);
 #endif
 #ifdef RUNTIME_INFO_L3
-			 sprintf(Str,"Rendered %d Polygons,%d Omnilights and %d particles.\n",CPolys,COmnies,CPcls);
+			 snprintf(Str, 80,"Rendered %d Polygons,%d Omnilights and %d particles.\n",CPolys,COmnies,CPcls);
 			 Y = OutTextXY(VPage,0,Y+15,Str,64);
 #endif
 			 //    DisplayMouse();
@@ -2151,7 +2151,7 @@ Away:Tot = Timer-TTrd;
 	//	printf("FPS == %f\n",100.0*(float)Frames/(float)Timer);
 	while (Keyboard[ScESC]) DO_NOP();
 	//Exec_FPS = 100.0*(float)Frames/(float)Par5;
-	/*  sprintf(Str,"Inst. FPS = %3.2f (%3.2f)",FPGS,100.0*(float)Frames/(float)Par4);
+	/*  snprintf(Str, 80,"Inst. FPS = %3.2f (%3.2f)",FPGS,100.0*(float)Frames/(float)Par4);
 	OutTextXY(VGAPtr,0,0,Str,63);
 	while (!Keyboard[ScESC]) DO_NOP();
 	while (Keyboard[ScESC]) DO_NOP();*/


### PR DESCRIPTION
## Summary

Every active `sprintf` call in `DEMO/` and `FDS/` becomes `snprintf(buf, sizeof(buf), …)`. For `FDS/RENDER/RENDER.CPP` the target `Str` is `new char[80]` rather than a stack array, so the literal `80` is passed instead of `sizeof` (which would return the pointer size).

- 8 files in DEMO/ (CITY, CRASH, Config, FOUNTAIN, FillerTest, GREETS, Glat, ImageCompression)
- 2 files in FDS/ (FILLERS/IXTGZ, RENDER/RENDER)

Commented-out `sprintf` calls are updated too so they stay consistent if re-enabled.

Behavior is unchanged — every buffer was already sized large enough for the intended output.

## Before / after warnings

Full clean rebuild:

- Before: 8 `'sprintf' is deprecated` warnings from stdio on macOS Command Line Tools.
- After: 0.

Two unrelated warnings remain and are out of scope for this PR:
- `ranlib: ... libModplayer.a the table of contents is empty` — the C++ wrapper has no compiled symbols of its own, it just forwards to the Rust static lib.
- `Config.cpp:155 fscanf %s with char(*)[128]` — pre-existing `&value` where plain `value` would be correct.

## Test plan

- [x] `cmake --build build --target clean && cmake --build build` — clean, no sprintf warnings
- [ ] `cd Runtime && ./DEMO` — verify on-screen profiler/FPS text in all scenes still renders correctly (City, Fountain, Greets show the bulk of these strings)