### PR TITLE
Match FLD load paths to on-disk casing

### DIFF
--- a/DEMO/CRASH.CPP
+++ b/DEMO/CRASH.CPP
@@ -10,7 +10,7 @@ void Initialize_Crash()
 {
 	CrashSc = (Scene *)getAlignedBlock(sizeof(Scene), 16);
 	memset(CrashSc,0,sizeof(Scene));
-	LoadFLD(CrashSc,"SCENES/Crash.FLD");
+	LoadFLD(CrashSc,"SCENES/CRASH.FLD");
 	CrPartTime = 1.5f*100.0f*(CrashSc->EndFrame-CrashSc->StartFrame)/30.0f;
 
 //	printf("FLD-loaded MEM = %d\n",DPMI_Free_Memory());

--- a/DEMO/FOUNTAIN.CPP
+++ b/DEMO/FOUNTAIN.CPP
@@ -684,7 +684,7 @@ void Initialize_Fountain()
 	FntSc = (Scene *)getAlignedBlock(sizeof(Scene), 16);
 	memset(FntSc,0,sizeof(Scene));
 
-	LoadFLD(FntSc,"SCENES/Fountain.FLD");
+	LoadFLD(FntSc,"SCENES/FOUNTAIN.FLD");
 
 	for(M = MatLib;M;M=M->Next)
 	{

--- a/DEMO/GREETS.CPP
+++ b/DEMO/GREETS.CPP
@@ -339,7 +339,7 @@ void Initialize_Greets()
 	GreetSc = (Scene *)getAlignedBlock(sizeof(Scene), 16);
 	memset(GreetSc,0,sizeof(Scene));
 	
-	LoadFLD(GreetSc,"SCENES/Greets.FLD");
+	LoadFLD(GreetSc,"SCENES/GREETS.FLD");
 
 	gg = new GreetsGenerator;
 


### PR DESCRIPTION
## Summary

Three of the five `LoadFLD(...)` calls in the scene Initializers used mixed-case paths that only resolve on case-insensitive filesystems (macOS default, Windows). On case-sensitive filesystems (Linux, ext4 / APFS case-sensitive) they would fail to find the shipped data.

| File | Before | After |
|---|---|---|
| `DEMO/CRASH.CPP` | `SCENES/Crash.FLD` | `SCENES/CRASH.FLD` |
| `DEMO/FOUNTAIN.CPP` | `SCENES/Fountain.FLD` | `SCENES/FOUNTAIN.FLD` |
| `DEMO/GREETS.CPP` | `SCENES/Greets.FLD` | `SCENES/GREETS.FLD` |

Shipped files at `Runtime/SCENES/` are all-caps, so this aligns source to disk.

## Audit context

A full audit of `#include` directives (DEMO/ + FDS/, 130 unique includes) and of source-file entries in every `CMakeLists.txt` came back clean — no case mismatches. The prior `FillerTest.cpp` fix (`3b09fcb`) caught the last one. These three `LoadFLD` call sites are the only remaining case-sensitivity issues I could find *on the code side*.

## Deliberately out of scope

Texture-path string literals like `"Textures/Code.JPG"`, `"Textures/p_text.jpg"` (in `GREETS.CPP`, `Glat.cpp`, `SkyCube.cpp`, `FOUNTAIN.CPP`, `ImageCompression.cpp`) have the same pattern but I'm leaving them. Texture filenames are also embedded inside `.FLD` binaries, so a code-side rename alone wouldn't make textures load on Linux — needs a coordinated data-side pass. Flagging it here so it isn't forgotten.

## Test plan

- [x] `cmake --build build` — clean build, no behavior change on macOS (case-insensitive FS resolves both forms).
- [ ] `cd Runtime && ./DEMO` — Chase/Fountain/Greets scenes still load. (On macOS these already worked; the fix only matters for Linux builds that don't exist yet.)