### PR TITLE
Clear remaining build warnings

### DIFF
--- a/DEMO/Config.cpp
+++ b/DEMO/Config.cpp
@@ -152,7 +152,7 @@ CFGEntry *ConfigurationDB::readEntry(FILE *F)
 	case 1:
 		{
 			char value[128];
-			fscanf(F, "%127s", &value);
+			fscanf(F, "%127s", value);
 			return new CFGString(buffer, value);
 		}
 		break;

--- a/Modplayer/CMakeLists.txt
+++ b/Modplayer/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(modplayer_rust PROPERTIES
     IMPORTED_LOCATION "${_modplayer_rust_lib}")
 add_dependencies(modplayer_rust modplayer_rust_build)
 
-# Thin C++ wrapper.
-add_library(${PROJECT_NAME} STATIC Modplayer.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(${PROJECT_NAME} PUBLIC modplayer_rust)
+# Header-only C++ facade — all implementation lives in the Rust lib.
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} INTERFACE modplayer_rust)

--- a/Modplayer/Modplayer.cpp
+++ b/Modplayer/Modplayer.cpp
@@ -1,1 +1,0 @@
-#include "Modplayer.h"


### PR DESCRIPTION
## Summary

- **Config.cpp:155** — `fscanf("%127s", &value)` passed the address of the array instead of the array itself (char (\*)[128] vs char \*). Same bytes in practice, but the format mismatch tripped `-Wformat`.
- **Modplayer/libModplayer.a** — ranlib warned the archive had no object members because `Modplayer.cpp` was a single `#include` with nothing to compile. Switched the target to an `INTERFACE` library that forwards the include dir + the imported Rust static lib, and removed the empty wrapper.

After this, `cmake --build build` produces zero warnings on macOS arm64.

## Test plan

- [x] Clean rebuild emits no warnings
- [x] `nm build/DEMO/DEMO | grep Modplayer_` still lists `Modplayer_Create/Start/Stop/SetOrder` — Rust symbols linked through the INTERFACE facade
- [ ] `cd Runtime && ./DEMO` plays music correctly (user verification)