### PR TITLE
Raise SDL window on startup so it gets focus

### DIFF
--- a/DEMO/REV.CPP
+++ b/DEMO/REV.CPP
@@ -1112,6 +1112,8 @@ int main(int argc, const char *argv[])
         g_demoXRes, g_demoYRes,
         0);
 
+    SDL_RaiseWindow(window);
+
 	// _controlfp(_EM_INEXACT, _MCW_EM);
 	FPU_LPrecision();
 	const int internalXRes = g_demoXRes;


### PR DESCRIPTION
## Summary
- On macOS, `SDL_CreateWindow` with no flags can place the window behind the launching terminal — the demo appears to run (music plays) but the window is hidden or unfocused.
- `SDL_RaiseWindow(window)` activates the app and brings the window to the front immediately after creation.

## Test plan
- [x] Build clean on macOS arm64
- [x] Run from `Runtime/` — window now comes up focused (confirmed in session)