### PR TITLE
CLAUDE.md: refresh Modplayer description and branch workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@ REVIVAL / FLOOD — a 1998 demoscene production being revived on modern platform
 
 - **DEMO/** — executable. Orchestrates scenes, owns `main()` + SDL event loop.
 - **FDS/** — static library. Custom software 3D engine (transform, lighting, clipper, rasterizer, model loaders, SIMD fillers).
-- **Modplayer/** — thin C++ static lib that links a *Rust* `libmodplayer.a` for `.MOD`/`.XM` playback.
+- **Modplayer/** — header-only CMake INTERFACE target that forwards its include directory and links a *Rust* `libmodplayer.a` built from the `Modplayer/modplayer` submodule for `.MOD`/`.XM` playback.
 
 ## Build (macOS arm64, current working config)
 
-The active branch is `macos`; `master` is the PR target. Builds out-of-tree with Ninja:
+Work lands on `master` via feature-branch PRs (branch names like `cleanup/*`, `fix/*`). Builds out-of-tree with Ninja:
 
 ```sh
 cmake -S . -B build -G Ninja


### PR DESCRIPTION
## Summary
Two drifted lines in CLAUDE.md:
- Modplayer is no longer a C++ static lib — PR #11 converted it to a CMake INTERFACE target that forwards include + link to the Rust submodule.
- The `macos` branch is stale — recent work all lands on master via feature-branch PRs (`cleanup/*`, `fix/*`).

## Test plan
- [x] Docs-only; no build impact.