### PR TITLE
Tick-based scene loops (Phase 1 + 2 of WASM refactor)

### DIFF
--- a/DEMO/CHASE.CPP
+++ b/DEMO/CHASE.CPP
@@ -4,6 +4,7 @@
 #include <Base/Scene.h>
 
 #include "CHASE.H"
+#include "SceneTick.h"
 
 #define FRONT_TO_BACK_SORTING
 static Scene *ChaseSc;
@@ -730,39 +731,37 @@ void Initialize_Chase()
 	//	printf("Scene-Proc MEM = %d\n",DPMI_Free_Memory());
 }
 
-void Run_Chase()
-{
-	int32_t Polys = 0;
-	TriMesh *T;
+namespace {
+struct ChaseScene : SceneDriver {
+	void init() override {
+		int32_t Polys = 0;
+		TriMesh *T;
 
-	SetCurrentScene(ChaseSc);
+		SetCurrentScene(ChaseSc);
 
-	Reflective_Mapper_Setup();
-	Setup_Water_Distort();
+		Reflective_Mapper_Setup();
+		Setup_Water_Distort();
 
+		for(T = ChaseSc->TriMeshHead; T; T = T->Next)
+			Polys += T->FIndex;
+		FList = new Face * [Polys];
+		SList = new Face * [Polys];
 
-	for(T = ChaseSc->TriMeshHead;T;T=T->Next)
-		Polys+=T->FIndex;
-	FList = new Face * [Polys];
-	SList = new Face * [Polys];
+		View = ChaseSc->CameraHead;
 
-	View = ChaseSc->CameraHead;
+		C_FZP = ChaseSc->FZP;
+		C_rFZP = 1.0f / C_FZP;
+	}
 
-	C_FZP = ChaseSc->FZP;
-	C_rFZP = 1.0f / C_FZP;
+	bool tick() override {
+		if (Keyboard[ScESC] || Timer >= CHPartTime) return false;
 
-
-
-	while ((!Keyboard[ScESC])&&Timer<CHPartTime)
-	{
 		g_FrameTime = Timer;
-		//memset(VPage,0,PageSize);
 		FastWrite(VPage, 0, (PageSize + XRes * YRes * sizeof(word)) >> 2);
 
 		CurFrame = ChaseSc->StartFrame + (ChaseSc->EndFrame-ChaseSc->StartFrame) * (float)g_FrameTime / (float)CHPartTime;
 
-		if (Keyboard[ScTab])
-		{
+		if (Keyboard[ScTab]) {
 			if (View == &FC)
 				View = ChaseSc->CameraHead;
 			else
@@ -780,38 +779,35 @@ void Run_Chase()
 
 		Reflected_Transform(ChaseSc);
 
-		if (!CAll) goto norefl;
-		Radix_SortingASM(FList,SList,CAll);
-
-		Render();
-
-	norefl:
+		if (CAll) {
+			Radix_SortingASM(FList, SList, CAll);
+			Render();
+		}
 
 		((TriMesh *)(RflObj->Data))->Flags |= HTrack_Visible;
 		Transform_Objects(ChaseSc);
-		if (!CAll) continue;
+		if (!CAll) return true;
 		Radix_SortingASM(FList, SList, CAll);
 		Render();
 
 		Flip(MainSurf);
-
-	} Timer-=CHPartTime;
-	/*
-	if (Keyboard[ScESC])
-	{
-		#ifdef Play_Music
-		ShutDown();
-		#endif
-		FDS_End();
-		exit(-1);
+		return true;
 	}
-	*/
 
-	while (Keyboard[ScESC]) continue;
-	if (Timer < 0)
-		Timer = 0;
+	void cleanup() override {
+		Timer -= CHPartTime;
+		while (Keyboard[ScESC]) continue;
+		if (Timer < 0) Timer = 0;
 
-	delete FList;
-	delete SList;
-	Destroy_Scene(ChaseSc);
+		delete FList;
+		delete SList;
+		Destroy_Scene(ChaseSc);
+	}
+};
+} // anonymous namespace
+
+void Run_Chase()
+{
+	ChaseScene scene;
+	runSceneBlocking(scene);
 }

--- a/DEMO/CHASE.CPP
+++ b/DEMO/CHASE.CPP
@@ -5,6 +5,7 @@
 
 #include "CHASE.H"
 #include "SceneTick.h"
+#include <memory>
 
 #define FRONT_TO_BACK_SORTING
 static Scene *ChaseSc;
@@ -733,6 +734,11 @@ void Initialize_Chase()
 
 namespace {
 struct ChaseScene : SceneDriver {
+	std::unique_ptr<Face*[]> fListStorage;
+	std::unique_ptr<Face*[]> sListStorage;
+
+	~ChaseScene() override { Destroy_Scene(ChaseSc); }
+
 	void init() override {
 		int32_t Polys = 0;
 		TriMesh *T;
@@ -744,8 +750,10 @@ struct ChaseScene : SceneDriver {
 
 		for(T = ChaseSc->TriMeshHead; T; T = T->Next)
 			Polys += T->FIndex;
-		FList = new Face * [Polys];
-		SList = new Face * [Polys];
+		fListStorage = std::make_unique<Face*[]>(Polys);
+		sListStorage = std::make_unique<Face*[]>(Polys);
+		FList = fListStorage.get();
+		SList = sListStorage.get();
 
 		View = ChaseSc->CameraHead;
 
@@ -798,10 +806,6 @@ struct ChaseScene : SceneDriver {
 		Timer -= CHPartTime;
 		while (Keyboard[ScESC]) continue;
 		if (Timer < 0) Timer = 0;
-
-		delete FList;
-		delete SList;
-		Destroy_Scene(ChaseSc);
 	}
 };
 } // anonymous namespace

--- a/DEMO/CITY.CPP
+++ b/DEMO/CITY.CPP
@@ -1,7 +1,9 @@
 
 #include "Rev.h"
 #include "CITY.H"
+#include "SceneTick.h"
 #include <algorithm>
+#include <memory>
 #include <vector>
 #include "FRUSTRUM.H"
 #include "Gradient.h"
@@ -1809,122 +1811,91 @@ std::vector<debug_outtext> DebugStrs;
 
 #endif
 
-void Run_City()
-{
-	int32_t Polys = 0,TTrd;
-	TriMesh *T;
-	Omni *O;
-
-	SetCurrentScene(CitySc);
-
-	// get the reflective water surface object
-	Reflective_Mapper_Setup();
-	Setup_Water_Distort();
-//	Setup_Grid_Texture_Mapper_XXX(256, 256);
-
-	// scatter point lights.
-	/*for(O=CitySc->OmniHead;O;O=O->Next)
-	{
-		Quaternion_Form(&O->Pos.Keys[0].Pos, 
-			((RAND_15()-16384)*5000.0)/16384.0,
-			(RAND_15()*2000.0)/32768.0,
-			((RAND_15()-16384)*5000.0)/16384.0,
-			0);
-	}*/
-
-
-	for(T = CitySc->TriMeshHead;T;T=T->Next)
-		Polys+=T->FIndex;
-	for(O = CitySc->OmniHead;O;O=O->Next)
-		Polys++;
-
-	//MusicModuleInfo mmi;
-	//mmi.ModuleHandle = g_RevModuleHandle;
-
-	FList = new Face * [Polys];
-	SList = new Face * [Polys];
-
-	View = CitySc->CameraHead;
-//	View = &FC;
-
-	int32_t i, timerStack[20], timerIndex = 0;
-	for(i=0; i<20; i++)
-		timerStack[i] = Timer;
-
-	C_FZP = CitySc->FZP;
-	C_rFZP = 1.0f/C_FZP;
-	//C_reFZP = 1.0f/(C_FZP*1.15f);
-
-	g_FrameTime = TTrd = Timer;
-
-//  old lighting model
-//	Ambient_Factor = 32;
-//	Diffusive_Factor = 10000000;//80 000 000;
-
-	Ambient_Factor = 0.25;
-	Diffusive_Factor = 1.0;
-	Specular_Factor = 0.0;
-	Range_Factor = 1.3;
-
-
-	ImageSize = 200;
+namespace {
+struct CityScene : SceneDriver {
 	char MSGStr[128];
-
-	// SYNC music: set order #7
-	//mmi.Order = 7;
-	//FModSetModuleInfo(mmi);
-
-	Modplayer_SetOrder(g_RevModuleHandle, 7);
-
+	std::unique_ptr<Face*[]> fListStorage;
+	std::unique_ptr<Face*[]> sListStorage;
+	int32_t TTrd = 0;
+	int32_t timerStack[20] = {};
+	int32_t timerIndex = 0;
 	dword numFrames = 0;
-
-	//dword avgPolys = 0;
-	g_renderedPolys = 0;
-	numDropsRendered = 0;
-
-	FillerPixelcount = 0;
-
-	dword Profiler[PROF_NUM];
-	float ProfSample[PROF_NUM];
-	float ProfPerc[PROF_NUM];
-	const char *ProfNames[] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
+	dword Profiler[PROF_NUM] = {};
+	float ProfSample[PROF_NUM] = {};
+	float ProfPerc[PROF_NUM] = {};
+	const char *ProfNames[PROF_NUM] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
 	dword ProfSum = 0;
+	bool pause_mode = false;
 
 	std::vector<int> dispMap;
-	dispMap.resize(XRes * YRes);
-
-	//float waves[10][2];
-	//for (int w = 0; w != 10; ++w) {
-	//	waves[w][0] = (1.0 / 50.0) * (2 * (RAND_15() / 32768.0f) - 1);
-	//	waves[w][1] = (1.0 / 50.0) * (2 * (RAND_15() / 32768.0f) - 1);
-	//	waves[w][2] = (1.0 / 50.0) * (2 * (RAND_15() / 32768.0f) - 1);
-	//	waves[w][3] = (1.0 / 50.0) * (2 * (RAND_15() / 32768.0f) - 1);
-	//}
-	int idx = 0;
-	for (int y = 0; y < YRes; ++y) {
-		for (int x = 0; x < XRes; ++x) {
-			int tx = x, ty = y;
-
-			//for (int w = 0; w != 10; ++w) {
-			//	tx += sin(x * waves[w][0] + y * waves[w][1]) * 3.5;
-			//	ty += cos(x * waves[w][0] + y * waves[w][1]) * 3.5;
-			//}
-			tx += sin(x/30.0) * 15;
-			ty += cos(y/50.0) * 15;
-
-			if (tx < 0) { tx = -tx; } if (tx > XRes_1) { tx = 2 * XRes_1 - tx; }
-			if (ty < 0) { ty = -ty; } if (ty > YRes_1) { ty = 2 * YRes_1 - ty; }
-			dispMap[idx++] = ty * XRes + tx;
-		}
-	}
 	std::vector<dword> backBuffer;
-	backBuffer.resize(XRes * YRes);
 
-	for(i=0; i<PROF_NUM; i++)
-		Profiler[i] = 0;	
+	~CityScene() override { Destroy_Scene(CitySc); }
 
-	while ((!Keyboard[ScESC]) && Timer < CTPartTime)
-	{
+	void init() override {
+		int32_t Polys = 0;
+		TriMesh *T;
+		Omni *O;
+
+		SetCurrentScene(CitySc);
+
+		// get the reflective water surface object
+		Reflective_Mapper_Setup();
+		Setup_Water_Distort();
+
+		for(T = CitySc->TriMeshHead; T; T = T->Next)
+			Polys += T->FIndex;
+		for(O = CitySc->OmniHead; O; O = O->Next)
+			Polys++;
+
+		fListStorage = std::make_unique<Face*[]>(Polys);
+		sListStorage = std::make_unique<Face*[]>(Polys);
+		FList = fListStorage.get();
+		SList = sListStorage.get();
+
+		View = CitySc->CameraHead;
+
+		for(int32_t i = 0; i < 20; i++)
+			timerStack[i] = Timer;
+
+		C_FZP = CitySc->FZP;
+		C_rFZP = 1.0f / C_FZP;
+
+		g_FrameTime = TTrd = Timer;
+
+		Ambient_Factor = 0.25;
+		Diffusive_Factor = 1.0;
+		Specular_Factor = 0.0;
+		Range_Factor = 1.3;
+
+		ImageSize = 200;
+
+		// SYNC music: set order #7
+		Modplayer_SetOrder(g_RevModuleHandle, 7);
+
+		g_renderedPolys = 0;
+		numDropsRendered = 0;
+		FillerPixelcount = 0;
+
+		dispMap.resize(XRes * YRes);
+		int idx = 0;
+		for (int y = 0; y < YRes; ++y) {
+			for (int x = 0; x < XRes; ++x) {
+				int tx = x, ty = y;
+				tx += sin(x/30.0) * 15;
+				ty += cos(y/50.0) * 15;
+
+				if (tx < 0) { tx = -tx; } if (tx > XRes_1) { tx = 2 * XRes_1 - tx; }
+				if (ty < 0) { ty = -ty; } if (ty > YRes_1) { ty = 2 * YRes_1 - ty; }
+				dispMap[idx++] = ty * XRes + tx;
+			}
+		}
+		backBuffer.resize(XRes * YRes);
+	}
+
+	bool tick() override {
+		if (Keyboard[ScESC] || Timer >= CTPartTime) return false;
+
 		numFrames++;
 
 		Profiler[PROF_ZCLR] -= Timer;
@@ -1932,24 +1903,20 @@ void Run_City()
 		dTime = Timer - TTrd;
 		if (dTime > 300) dTime = 300;
 		// fast forward/rewind
-		if (Keyboard[ScF2])
-		{
+		if (Keyboard[ScF2]) {
 			Timer += dTime * 8;
 		}
-		if (Keyboard[ScF1])
-		{
+		if (Keyboard[ScF1]) {
 			if (dTime * 8 > Timer)
 				Timer = 0;
 			else
 				Timer -= dTime * 8;
 		}
-		static bool pause_mode = false;
 		if (Keyboard[ScP])
 			pause_mode = true;
 		if (Keyboard[ScU])
 			pause_mode = false;
-		if (pause_mode)
-		{
+		if (pause_mode) {
 			Timer = TTrd;
 		}
 		g_FrameTime = TTrd = Timer;
@@ -1963,18 +1930,13 @@ void Run_City()
 		Dynamic_Camera();
 
 		// Clear framebuffer and Z-buffer
-		//memset(VPage,0,PageSize + XRes*YRes*sizeof(word));
 		FastWrite(VPage, 0, (PageSize + XRes * YRes * sizeof(word)) >> 2);
 		RenderSkyCube(SkySc, View, false);
-//		FastWrite(VPage + PageSize, 0, (XRes * YRes * sizeof(word)) >> 2);
 
 		Profiler[PROF_ZCLR] += Timer;
 		Profiler[PROF_ANIM] -= Timer;
 
 		Reflective_AnimateTexture();
-		//		Water_Distort();
-
-		//							 CitySc->StartFrame + 500 * (float)Timer / (float)CTPartTime;
 
 		if (Keyboard[ScC]) { FC.ISource = View->ISource; Matrix_Copy(FC.Mat, View->Mat); FC.IFOV = View->IFOV; }
 
@@ -1986,7 +1948,6 @@ void Run_City()
 		Profiler[PROF_LGHT] -= Timer;
 
 		Lighting(CitySc);
-		//City_Lighting();
 
 		// NOTE: Profiler ignores rain f/x
 #ifdef CITY_RAIN
@@ -1998,48 +1959,38 @@ void Run_City()
 		// render reflection of all objects except water
 		Reflected_Transform(CitySc);
 
-
 		Profiler[PROF_XFRM] += Timer;
 
-		if (!CAll) goto norefl;
-		Profiler[PROF_SORT] -= Timer;
+		if (CAll) {
+			Profiler[PROF_SORT] -= Timer;
 
-		Radix_SortingASM(FList, SList, CAll);
+			Radix_SortingASM(FList, SList, CAll);
 
-		Profiler[PROF_SORT] += Timer;
-		Profiler[PROF_RNDR] -= Timer;
+			Profiler[PROF_SORT] += Timer;
+			Profiler[PROF_RNDR] -= Timer;
 
-		Render();
-		{
-			memcpy(backBuffer.data(), VPage, PageSize);
-			int ii = 0;
-			dword* ptr = (dword*)VPage;
-			uint16_t* zbuffer_ptr = (uint16_t*)(VPage + PageSize);
-			for (auto displacement : dispMap) {
-				if (*zbuffer_ptr++ != 0) {
-					*ptr = backBuffer[displacement];
+			Render();
+			{
+				memcpy(backBuffer.data(), VPage, PageSize);
+				dword* ptr = (dword*)VPage;
+				uint16_t* zbuffer_ptr = (uint16_t*)(VPage + PageSize);
+				for (auto displacement : dispMap) {
+					if (*zbuffer_ptr++ != 0) {
+						*ptr = backBuffer[displacement];
+					}
+					ptr++;
 				}
-				ptr++;
 			}
+
+			Profiler[PROF_RNDR] += Timer;
 		}
-
-
-		Profiler[PROF_RNDR] += Timer;
-
-		//Reflective_Distortion();
-		//Run_Distort();
-		// Clear framebuffer and Z-buffer
-		//memset(VPage,0,PageSize + XRes*YRes*sizeof(word));		
-//		FastWrite(VPage+PageSize, 0, (XRes*YRes*sizeof(word)) >> 2);
-
-	norefl:
 
 		// render all objects normally
 		Profiler[PROF_XFRM] -= Timer;
 		((TriMesh*)(RflObj->Data))->Flags |= HTrack_Visible;
 		Transform_Objects(CitySc);
 		Profiler[PROF_XFRM] += Timer;
-		if (!CAll) continue;
+		if (!CAll) return true;
 		Profiler[PROF_SORT] -= Timer;
 		Radix_SortingASM(FList, SList, CAll);
 		Profiler[PROF_SORT] += Timer;
@@ -2049,17 +2000,14 @@ void Run_City()
 		Profiler[PROF_RNDR] += Timer;
 
 		// FPS printer
-		if (g_profilerActive)
-		{
+		if (g_profilerActive) {
 			mword scroll = 0;
 
 			timerStack[timerIndex++] = Timer;
-			if (timerIndex == 20)
-			{
+			if (timerIndex == 20) {
 				timerIndex = 0;
 				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[19] - timerStack[timerIndex]));
-			}
-			else {
+			} else {
 				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0 / (float)(timerStack[timerIndex - 1] - timerStack[timerIndex]));
 			}
 			scroll = OutTextXY(VPage, 0, scroll, MSGStr, 255);
@@ -2072,25 +2020,14 @@ void Run_City()
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame", (int32_t)(g_renderedPolys / numFrames));
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-			//		numDropsRendered=0;
-			//		snprintf(MSGStr, sizeof(MSGStr), "%d raindrops" , (int32_t)(numDropsRendered) );
-			//		OutTextXY(VPage,0,60,MSGStr,255);
 
-			//		FModGetModuleInfo(mmi);
-			//		snprintf(MSGStr, sizeof(MSGStr), "Order: %d, Row: %d", mmi.Order, mmi.Row);
-			//		OutTextXY(VPage,0,15,MSGStr,255);
-			//		snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second" , (int32_t)(FillerPixelcount/1000.0 * 100.0 / Timer));
-			//		OutTextXY(VPage,0,30,MSGStr,255);
-			//		PROFILER: display stats		
-			for (i = 0; i < PROF_NUM; i++)
-			{
+			for (int32_t i = 0; i < PROF_NUM; i++) {
 				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)", ProfNames[i], ProfSample[i], ProfPerc[i]);
 				scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 			}
 
 			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms", ProfSum * 10.0 / numFrames);
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-
 		}
 		Profiler[PROF_FLIP] -= Timer;
 
@@ -2104,32 +2041,27 @@ void Run_City()
 		Flip(MainSurf);
 		Profiler[PROF_FLIP] += Timer;
 
-		//		PROFILER: Generate sample
+		// PROFILER: Generate sample
 		ProfSum = 0;
-		for (i = 0; i < PROF_NUM; i++)
+		for (int32_t i = 0; i < PROF_NUM; i++)
 			ProfSum += Profiler[i];
-		for (i = 0; i < PROF_NUM; i++)
-		{
-			ProfSample[i] =
-				Profiler[i] * 10.0 / numFrames;
-			ProfPerc[i] =
-				Profiler[i] * 100.0 / ProfSum;
+		for (int32_t i = 0; i < PROF_NUM; i++) {
+			ProfSample[i] = Profiler[i] * 10.0 / numFrames;
+			ProfPerc[i] = Profiler[i] * 100.0 / ProfSum;
 		}
+		return true;
+	}
 
-		//if (dTime<5) SysSleep(10*(5-dTime));
-	} Timer -= CTPartTime;
-/*	if (Keyboard[ScESC])
-	{
-		#ifdef Play_Music
-		ShutDown();
-		#endif
-		FDS_End();
-		exit(-1);
-	}*/
-	while (Keyboard[ScESC]) continue;
-	if (Timer < 0)
-		Timer = 0;
-	delete FList;
-	delete SList;
-	Destroy_Scene(CitySc);
+	void cleanup() override {
+		Timer -= CTPartTime;
+		while (Keyboard[ScESC]) continue;
+		if (Timer < 0) Timer = 0;
+	}
+};
+} // anonymous namespace
+
+void Run_City()
+{
+	CityScene scene;
+	runSceneBlocking(scene);
 }

--- a/DEMO/CMakeLists.txt
+++ b/DEMO/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DEMO_SOURCES
     Raytracer.h
     REV.CPP
     Rev.h
+    SceneTick.h
     SDL2.cpp
     SDL2.h)
 

--- a/DEMO/CRASH.CPP
+++ b/DEMO/CRASH.CPP
@@ -2,6 +2,7 @@
 
 #include "CRASH.H"
 #include "SceneTick.h"
+#include <memory>
 
 static Scene *CrashSc;
 
@@ -39,6 +40,10 @@ void Initialize_Crash()
 namespace {
 struct CrashScene : SceneDriver {
 	char MSGStr[128];
+	std::unique_ptr<Face*[]> fListStorage;
+	std::unique_ptr<Face*[]> sListStorage;
+
+	~CrashScene() override { Destroy_Scene(CrashSc); }
 
 	void init() override {
 		int32_t Polys = 0;
@@ -54,8 +59,10 @@ struct CrashScene : SceneDriver {
 			Polys++;
 		}
 
-		FList = new Face * [Polys];
-		SList = new Face * [Polys];
+		fListStorage = std::make_unique<Face*[]>(Polys);
+		sListStorage = std::make_unique<Face*[]>(Polys);
+		FList = fListStorage.get();
+		SList = sListStorage.get();
 
 		View = CrashSc->CameraHead;
 
@@ -118,10 +125,6 @@ struct CrashScene : SceneDriver {
 		// eventual Emscripten port this will need to become a tick state.
 		while (Keyboard[ScESC]) continue;
 		if (Timer < 0) Timer = 0;
-
-		delete FList;
-		delete SList;
-		Destroy_Scene(CrashSc);
 	}
 };
 } // anonymous namespace

--- a/DEMO/CRASH.CPP
+++ b/DEMO/CRASH.CPP
@@ -1,6 +1,7 @@
 #include "Rev.h"
 
 #include "CRASH.H"
+#include "SceneTick.h"
 
 static Scene *CrashSc;
 
@@ -35,40 +36,43 @@ void Initialize_Crash()
 	Preprocess_Scene(CrashSc);
 }
 
-void Run_Crash()
-{
+namespace {
+struct CrashScene : SceneDriver {
 	char MSGStr[128];
 
-	int32_t Polys = 0;
-	TriMesh *T;
-	Omni *O;
+	void init() override {
+		int32_t Polys = 0;
+		TriMesh *T;
+		Omni *O;
 
-	SetCurrentScene(CrashSc);
+		SetCurrentScene(CrashSc);
 
-	for(T = CrashSc->TriMeshHead;T;T=T->Next)
-		Polys+=T->FIndex;
-	for (O = CrashSc->OmniHead; O; O = O->Next) {
-		O->IRange = 2000.0f;
-		Polys++;
+		for(T = CrashSc->TriMeshHead; T; T=T->Next)
+			Polys += T->FIndex;
+		for (O = CrashSc->OmniHead; O; O = O->Next) {
+			O->IRange = 2000.0f;
+			Polys++;
+		}
+
+		FList = new Face * [Polys];
+		SList = new Face * [Polys];
+
+		View = CrashSc->CameraHead;
+
+		C_FZP = CrashSc->FZP;
+		C_rFZP = 1.0f / C_FZP;
+
+		Ambient_Factor = 1;
+		Diffusive_Factor = 1;
+		ImageSize = 1;
 	}
 
-	FList = new Face * [Polys];
-	SList = new Face * [Polys];
+	bool tick() override {
+		if (Keyboard[ScESC] || Timer >= CrPartTime) return false;
 
-	View = CrashSc->CameraHead;
-
-	C_FZP = CrashSc->FZP;
-	C_rFZP = 1.0f/C_FZP;
-
-	Ambient_Factor = 1;
-	Diffusive_Factor = 1;
-	ImageSize = 1;
-	while ((!Keyboard[ScESC])&&Timer<CrPartTime)
-	{
 		g_FrameTime = Timer;
 
-		if (Keyboard[ScTab])
-		{
+		if (Keyboard[ScTab]) {
 			if (View == &FC)
 				View = CrashSc->CameraHead;
 			else
@@ -89,8 +93,8 @@ void Run_Crash()
 
 		Lighting(CrashSc);
 
-		if (!CAll) continue;
-		Radix_SortingASM(FList,SList,CAll);
+		if (!CAll) return true;
+		Radix_SortingASM(FList, SList, CAll);
 
 		Render();
 
@@ -103,22 +107,27 @@ void Run_Crash()
 		scroll += OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
 
 		Flip(MainSurf);
+		return true;
+	}
 
-	} Timer-=CrPartTime;
+	void cleanup() override {
+		Timer -= CrPartTime;
 
-	while (Keyboard[ScESC]) continue;
-	if (Timer < 0) Timer = 0;
+		// Wait for the user to release ESC before returning, otherwise the
+		// next scene will immediately see Keyboard[ScESC] and bail. In the
+		// eventual Emscripten port this will need to become a tick state.
+		while (Keyboard[ScESC]) continue;
+		if (Timer < 0) Timer = 0;
 
-/*	if (Keyboard[ScESC])
-	{
-		#ifdef Play_Music
-		ShutDown();
-		#endif
-		FDS_End();
-		exit(-1);
-	}*/
+		delete FList;
+		delete SList;
+		Destroy_Scene(CrashSc);
+	}
+};
+} // anonymous namespace
 
-	delete FList;
-	delete SList;
-	Destroy_Scene(CrashSc);
+void Run_Crash()
+{
+	CrashScene scene;
+	runSceneBlocking(scene);
 }

--- a/DEMO/FOUNTAIN.CPP
+++ b/DEMO/FOUNTAIN.CPP
@@ -5,6 +5,7 @@
 #include "Gradient.h"
 #include "FRUSTRUM.H"
 #include "Clipper.h"
+#include "SceneTick.h"
 
 static Scene *FntSc;
 static Vector FntHead(-0.053f,43.381f, 0.251f);
@@ -1806,94 +1807,85 @@ void Add_Vortex_ToScene()
 }
 extern Scene* SkySc;
 
-void Run_Fountain()
-{
-	int32_t Polys = 0;
-	TriMesh *T;
-	Omni *O;
-	int32_t TTrd;
-	Vector U,V;
-
-	byte *BPage = new byte[PageSize];
-
-#define VSurface MainSurf
-	VESA_Surface Blur;
-	memcpy(&Blur,VSurface,sizeof(VESA_Surface));
-	Blur.Data = BPage;
-	Blur.Flags = VSurf_Noalloc;
-	Blur.Targ = VGAPtr;
-
-	int32_t i, timerStack[20], timerIndex = 0;
-	for(i=0; i<20; i++)
-		timerStack[i] = Timer;
-
-//Setup_Grid_Texture_Mapper_XXX(256, 256);
-
-	SetCurrentScene(FntSc);
-	for(T = FntSc->TriMeshHead;T;T=T->Next)
-		Polys+=T->FIndex;
-	for(O = FntSc->OmniHead;O;O=O->Next)
-		Polys++;
-	Polys += FntSc->NumOfParticles;
-	FList = new Face * [Polys];
-	SList = new Face * [Polys];
-
-
-	View = FntSc->CameraHead;
-//	View = &FC;
-
-	//Timer = 4000;
-	TTrd = Timer;
+namespace {
+struct FountainScene : SceneDriver {
+	byte *BPage = nullptr;
+	VESA_Surface Blur = {};
+	int32_t timerStack[20] = {};
+	int32_t timerIndex = 0;
+	int32_t TTrd = 0;
 	mword numFrames = 0;
-
-	CParticle_ISize = 0.07f;
-	Ambient_Factor = basicSceneAmbient;
-	Diffusive_Factor = 500.0f;
-	ImageSize = 10.0;
-
-	g_renderedPolys = 0;
-	FillerPixelcount = 0;
-
-	dword Profiler[PROF_NUM];
-	float ProfSample[PROF_NUM];
-	float ProfPerc[PROF_NUM];
-	const char *ProfNames[] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
+	dword Profiler[PROF_NUM] = {};
+	float ProfSample[PROF_NUM] = {};
+	float ProfPerc[PROF_NUM] = {};
+	const char *ProfNames[PROF_NUM] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
 	dword ProfSum = 0;
+	bool pause_mode = false;
 
-	for(i=0; i<PROF_NUM; i++)
-		Profiler[i] = 0;	
+	void init() override {
+		int32_t Polys = 0;
+		TriMesh *T;
+		Omni *O;
 
-	while ((!Keyboard[ScESC])&&Timer<FNTPartTime)
-	{
+		BPage = new byte[PageSize];
+
+		memcpy(&Blur, MainSurf, sizeof(VESA_Surface));
+		Blur.Data = BPage;
+		Blur.Flags = VSurf_Noalloc;
+		Blur.Targ = VGAPtr;
+
+		for(int32_t i = 0; i < 20; i++)
+			timerStack[i] = Timer;
+
+		SetCurrentScene(FntSc);
+		for(T = FntSc->TriMeshHead; T; T = T->Next)
+			Polys += T->FIndex;
+		for(O = FntSc->OmniHead; O; O = O->Next)
+			Polys++;
+		Polys += FntSc->NumOfParticles;
+		FList = new Face * [Polys];
+		SList = new Face * [Polys];
+
+		View = FntSc->CameraHead;
+
+		TTrd = Timer;
+
+		CParticle_ISize = 0.07f;
+		Ambient_Factor = basicSceneAmbient;
+		Diffusive_Factor = 500.0f;
+		ImageSize = 10.0;
+
+		g_renderedPolys = 0;
+		FillerPixelcount = 0;
+	}
+
+	bool tick() override {
+		if (Keyboard[ScESC] || Timer >= FNTPartTime) return false;
+
 		numFrames++;
 
 		Profiler[PROF_ZCLR] -= Timer;
 
-//		memset(VPage, 0, PageSize + XRes*YRes*sizeof(word));
 		FastWrite(VPage, 0, (PageSize + XRes*YRes*sizeof(word)) >> 2);
 		bool SkipCameraAnimation = false;
 		RenderSkyCube(SkySc, View, SkipCameraAnimation);
 
-		dTime = Timer-TTrd;
+		dTime = Timer - TTrd;
 		// fast forward/rewind
-		if (Keyboard[ScF2])
-		{
+		if (Keyboard[ScF2]) {
 			Timer += dTime * 8;
 		}
-		if (Keyboard[ScF1])
-		{
+		if (Keyboard[ScF1]) {
 			if (dTime * 8 > Timer)
 				Timer = 0;
 			else
 				Timer -= dTime * 8;
 		}
-		static bool pause_mode = false;
 		if (Keyboard[ScP])
 			pause_mode = true;
 		if (Keyboard[ScU])
 			pause_mode = false;
-		if (pause_mode)
-		{
+		if (pause_mode) {
 			Timer = TTrd;
 		}
 		g_FrameTime = TTrd = Timer;
@@ -1903,8 +1895,7 @@ void Run_Fountain()
 
 		Dynamic_Camera();
 		if (Keyboard[ScC]) {FC.ISource = View->ISource; Matrix_Copy(FC.Mat,View->Mat); FC.IFOV=View->IFOV;}
-		if (Keyboard[ScTab])
-		{
+		if (Keyboard[ScTab]) {
 			if (View == &FC)
 				View = FntSc->CameraHead;
 			else
@@ -1915,156 +1906,118 @@ void Run_Fountain()
 
 		CurFrame = FntSc->StartFrame + (FntSc->EndFrame-FntSc->StartFrame) * (float)g_FrameTime / (float)FNTPartTime;
 
-		if (Timer>FntVortexStart)
-		{
+		if (Timer > FntVortexStart) {
 			Vortex_Distort();
 			float scl;
-			if (Timer>FntVortexMax)
+			if (Timer > FntVortexMax)
 				scl = 1.0f + 0.1 * sin((Timer - FntVortexMax)*0.01);
 			else
 				scl = (float)(Timer-FntVortexStart)/(float)(FntVortexMax-FntVortexStart);
-			Quaternion_Form(&VortexTri.Scale.Keys->Pos,scl,scl,scl,0.0f);
-			//Quaternion_Form(&VortexTri.Scale.Keys->Pos,1.0,1.0,1.0,0.0f);
-			
-//			Vector_Form(&VortexTri.Verts[0].Pos,-150.0f*scl,0.0f,-150.0f*scl);
-//			Vector_Form(&VortexTri.Verts[1].Pos,-150.0f*scl,0.0f, 150.0f*scl);
-//			Vector_Form(&VortexTri.Verts[2].Pos, 150.0f*scl,0.0f, 150.0f*scl);
-//			Vector_Form(&VortexTri.Verts[3].Pos, 150.0f*scl,0.0f,-150.0f*scl);
+			Quaternion_Form(&VortexTri.Scale.Keys->Pos, scl, scl, scl, 0.0f);
 		}
 
 		Animate_Objects(FntSc);
 
-//		float xfov = View->IFOV;
-//		float zf = tan(xfov*PI/360.0);
-//		float yfov = 360.0/PI * atan(zf*3.0/4.0);
-
-		if (Timer>FntVortexStart)
-		{
+		if (Timer > FntVortexStart) {
 			VortexTri.Flags |= HTrack_Visible;
 		} else VortexTri.Flags &= 0xFFFFFFFF-HTrack_Visible;
 
 		Particle_Kinematics(FntSc);
-		Profiler[PROF_ANIM] += Timer;		
-		Profiler[PROF_XFRM] -= Timer;		
+		Profiler[PROF_ANIM] += Timer;
+		Profiler[PROF_XFRM] -= Timer;
 
 		Transform_Objects(FntSc);
 
-		Profiler[PROF_XFRM] += Timer;		
-		Profiler[PROF_LGHT] -= Timer;		
+		Profiler[PROF_XFRM] += Timer;
+		Profiler[PROF_LGHT] -= Timer;
 
 		Lighting(FntSc);
 
-		Profiler[PROF_LGHT] += Timer;		
+		Profiler[PROF_LGHT] += Timer;
 
-		if (!CAll) continue;
-		Profiler[PROF_SORT] -= Timer;		
-		Radix_SortingASM(FList,SList,CAll);
-		Profiler[PROF_SORT] += Timer;		
+		if (!CAll) return true;
+		Profiler[PROF_SORT] -= Timer;
+		Radix_SortingASM(FList, SList, CAll);
+		Profiler[PROF_SORT] += Timer;
 
-//		Run_Rain();
-
-		Profiler[PROF_RNDR] -= Timer;		
+		Profiler[PROF_RNDR] -= Timer;
 		Render();
 
-//		snprintf(MSGStr, sizeof(MSGStr),"Rendered %d Polys,%d Omnis and %d pcls.\n",CPolys,COmnies,CPcls);
-//		OutTextXY(VPage,0,0,MSGStr,64);
-
-		if (Rsv_LState)
-		{
-			if (Rsv_LPow>-1)
-			{
-				Lightning_Bolt(&Rsv_LSrc,&Rsv_LTarg,Rsv_LPow, g_LnMat);
+		if (Rsv_LState) {
+			if (Rsv_LPow > -1) {
+				Lightning_Bolt(&Rsv_LSrc, &Rsv_LTarg, Rsv_LPow, g_LnMat);
 				Rsv_LState = 0;
 			} else {
-//				Spark(Pylon  ,Pylon+1);
-//				Spark(Pylon+1,Pylon+2);
-//				Spark(Pylon+2,Pylon+3);
-//				Spark(Pylon+3,Pylon+4);
-//				Spark(Pylon+4,Pylon+5);
-//				Spark(Pylon+5,Pylon  );
 				Rsv_LState = 0;
 			}
 		}
-		Profiler[PROF_RNDR] += Timer;		
+		Profiler[PROF_RNDR] += Timer;
 
-/*		if (Timer>FntPhotonStart)
-		{
-			if (Timer>FntPhotonAtVortex)
-				Fire_Photon_Beam(&FntHead,&Vortex_Center);
-			else
-			{
-				Vector_Sub(&Vortex_Center,&FntHead,&V);
-				Vector_SelfScale(&V,(float)(Timer-FntPhotonStart)/(float)(FntPhotonAtVortex-FntPhotonStart));
-				Vector_SelfAdd(&V,&FntHead);
-				Fire_Photon_Beam(&FntHead,&V);
-			}
-		}*/
-		if (g_profilerActive)
-		{
+		if (g_profilerActive) {
 			mword scroll = 0;
 			// FPS printer
 			timerStack[timerIndex++] = Timer;
-			if (timerIndex==20) 
-			{
+			if (timerIndex == 20) {
 				timerIndex = 0;
-				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]));
 			} else {
-				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]));
 			}
-			scroll = OutTextXY(VPage,0,0,MSGStr,255);
-			snprintf(MSGStr, sizeof(MSGStr),"%d outer pcls", g_numPcls);
-			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/frame" , (int32_t)(FillerPixelcount/(1000.0*numFrames)));
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
-			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second" , (int32_t)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
+			scroll = OutTextXY(VPage, 0, 0, MSGStr, 255);
+			snprintf(MSGStr, sizeof(MSGStr), "%d outer pcls", g_numPcls);
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/frame", (int32_t)(FillerPixelcount/(1000.0*numFrames)));
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second", (int32_t)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 
-			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame" , (int32_t)(g_renderedPolys / numFrames) );
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
+			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame", (int32_t)(g_renderedPolys / numFrames));
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 
-	//		PROFILER: display stats
-			for(i=0; i<PROF_NUM; i++)
-			{
-				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)" , ProfNames[i], ProfSample[i], ProfPerc[i]);
-				scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
+			for(int32_t i = 0; i < PROF_NUM; i++) {
+				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)", ProfNames[i], ProfSample[i], ProfPerc[i]);
+				scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 			}
 
-			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms" , ProfSum*10.0/ numFrames);
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
+			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms", ProfSum*10.0/numFrames);
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 		}
-		Profiler[PROF_FLIP] -= Timer;		
-//		Lightning_Particles();
+		Profiler[PROF_FLIP] -= Timer;
 
-		Flip(VSurface);
-		//Modulate(VSurface,&Blur,0x808080,0x808080);
-		//Flip(&Blur);
-		Profiler[PROF_FLIP] += Timer;		
+		Flip(MainSurf);
+		Profiler[PROF_FLIP] += Timer;
 
-
-//		PROFILER: Generate sample
+		// PROFILER: Generate sample
 		ProfSum = 0;
-		for(i=0; i<PROF_NUM; i++)
+		for(int32_t i = 0; i < PROF_NUM; i++)
 			ProfSum += Profiler[i];
-		for(i=0; i<PROF_NUM; i++)
-		{
-			ProfSample[i] =
-				Profiler[i]*10.0 / numFrames;
-			ProfPerc[i] = 
-				Profiler[i]*100.0/ProfSum;
+		for(int32_t i = 0; i < PROF_NUM; i++) {
+			ProfSample[i] = Profiler[i]*10.0 / numFrames;
+			ProfPerc[i] = Profiler[i]*100.0/ProfSum;
 		}
-	} 
-	Timer-=FNTPartTime;
-	while (Keyboard[ScESC]) continue;
-	if (Timer < 0) Timer = 0;
-
-	FILE *F = fopen("fountain-profiling.txt", "wt");
-	for(i=0; i<PROF_NUM; i++)
-	{
-		fprintf(F, "%s %3.1fms (%3.1f%%)\n" , ProfNames[i], ProfSample[i], ProfPerc[i]);
+		return true;
 	}
-	fclose(F);
-	
-	delete FList;
-	delete SList;
-	delete [] BPage;
-	Destroy_Scene(FntSc);
+
+	void cleanup() override {
+		Timer -= FNTPartTime;
+		while (Keyboard[ScESC]) continue;
+		if (Timer < 0) Timer = 0;
+
+		FILE *F = fopen("fountain-profiling.txt", "wt");
+		for(int32_t i = 0; i < PROF_NUM; i++) {
+			fprintf(F, "%s %3.1fms (%3.1f%%)\n", ProfNames[i], ProfSample[i], ProfPerc[i]);
+		}
+		fclose(F);
+
+		delete FList;
+		delete SList;
+		delete [] BPage;
+		Destroy_Scene(FntSc);
+	}
+};
+} // anonymous namespace
+
+void Run_Fountain()
+{
+	FountainScene scene;
+	runSceneBlocking(scene);
 }

--- a/DEMO/FOUNTAIN.CPP
+++ b/DEMO/FOUNTAIN.CPP
@@ -6,6 +6,7 @@
 #include "FRUSTRUM.H"
 #include "Clipper.h"
 #include "SceneTick.h"
+#include <memory>
 
 static Scene *FntSc;
 static Vector FntHead(-0.053f,43.381f, 0.251f);
@@ -1809,7 +1810,9 @@ extern Scene* SkySc;
 
 namespace {
 struct FountainScene : SceneDriver {
-	byte *BPage = nullptr;
+	std::unique_ptr<byte[]> BPage;
+	std::unique_ptr<Face*[]> fListStorage;
+	std::unique_ptr<Face*[]> sListStorage;
 	VESA_Surface Blur = {};
 	int32_t timerStack[20] = {};
 	int32_t timerIndex = 0;
@@ -1822,15 +1825,17 @@ struct FountainScene : SceneDriver {
 	dword ProfSum = 0;
 	bool pause_mode = false;
 
+	~FountainScene() override { Destroy_Scene(FntSc); }
+
 	void init() override {
 		int32_t Polys = 0;
 		TriMesh *T;
 		Omni *O;
 
-		BPage = new byte[PageSize];
+		BPage = std::make_unique<byte[]>(PageSize);
 
 		memcpy(&Blur, MainSurf, sizeof(VESA_Surface));
-		Blur.Data = BPage;
+		Blur.Data = BPage.get();
 		Blur.Flags = VSurf_Noalloc;
 		Blur.Targ = VGAPtr;
 
@@ -1843,8 +1848,10 @@ struct FountainScene : SceneDriver {
 		for(O = FntSc->OmniHead; O; O = O->Next)
 			Polys++;
 		Polys += FntSc->NumOfParticles;
-		FList = new Face * [Polys];
-		SList = new Face * [Polys];
+		fListStorage = std::make_unique<Face*[]>(Polys);
+		sListStorage = std::make_unique<Face*[]>(Polys);
+		FList = fListStorage.get();
+		SList = sListStorage.get();
 
 		View = FntSc->CameraHead;
 
@@ -2007,11 +2014,6 @@ struct FountainScene : SceneDriver {
 			fprintf(F, "%s %3.1fms (%3.1f%%)\n", ProfNames[i], ProfSample[i], ProfPerc[i]);
 		}
 		fclose(F);
-
-		delete FList;
-		delete SList;
-		delete [] BPage;
-		Destroy_Scene(FntSc);
 	}
 };
 } // anonymous namespace

--- a/DEMO/GREETS.CPP
+++ b/DEMO/GREETS.CPP
@@ -3,6 +3,7 @@
 #include "GREETS.H"
 #include "FillerTest.h"
 #include "MISC/PREPROC.H"
+#include "SceneTick.h"
 #include "Base/FDS_DECS.H"
 #include <vector>
 #include <VESA/Vesa.h>
@@ -404,111 +405,96 @@ void Initialize_Greets()
 //	}
 //}
 
-void Run_Greets()
-{
+namespace {
+struct GreetsScene : SceneDriver {
 	char MSGStr[128];
-	int32_t Polys = 0, TTrd;
-	TriMesh *T;
-	Omni *O;
-
-	int32_t i, timerStack[20], timerIndex = 0;
-	for(i=0; i<20; i++)
-		timerStack[i] = Timer;
-
-	SetCurrentScene(GreetSc);
-//	for(T = GreetSc->TriMeshHead;T;T=T->Next)
-	for(Object *Obj = GreetSc->ObjectHead;Obj;Obj=Obj->Next)
-	{
-		if (Obj->Type != Obj_TriMesh) continue;
-		T = (TriMesh *)Obj->Data;
-//		if (!stricmp(Obj->Name, "piramid.lwo"))
-//			T->Flags &=~HTrack_Visible;
-		Polys+=T->FIndex;
-	}
-		
-	for(O = GreetSc->OmniHead;O;O=O->Next)
-		Polys++;
-
-	FList = new Face * [Polys];
-	SList = new Face * [Polys];
-
-	View = GreetSc->CameraHead;
-
-	Ambient_Factor = 0.25;
-	Diffusive_Factor = 1.0;
-	Specular_Factor = 0.0;
-	Range_Factor = 1.0;
-	ImageSize = 0.25;//2.5;
-
+	int32_t TTrd = 0;
+	int32_t timerStack[20] = {};
+	int32_t timerIndex = 0;
 	dword numFrames = 0;
-
-
-	// this scene messes up at time zero
-	Timer++;
-
-	TTrd = Timer;
-	g_renderedPolys = 0;
-	FillerPixelcount = 0;
-
-
-	dword Profiler[PROF_NUM];
-	float ProfSample[PROF_NUM];
-	float ProfPerc[PROF_NUM];
-	const char *ProfNames[] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
+	dword Profiler[PROF_NUM] = {};
+	float ProfSample[PROF_NUM] = {};
+	float ProfPerc[PROF_NUM] = {};
+	const char *ProfNames[PROF_NUM] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
 	dword ProfSum = 0;
+	bool pause_mode = false;
 
-	for(i=0; i<PROF_NUM; i++)
-		Profiler[i] = 0;	
+	void init() override {
+		int32_t Polys = 0;
+		TriMesh *T;
+		Omni *O;
 
+		for(int32_t i = 0; i < 20; i++)
+			timerStack[i] = Timer;
 
-//	View = &FC;	
-	while ((!Keyboard[ScESC])&&Timer<CHPartTime)
-	{
+		SetCurrentScene(GreetSc);
+		for(Object *Obj = GreetSc->ObjectHead; Obj; Obj = Obj->Next) {
+			if (Obj->Type != Obj_TriMesh) continue;
+			T = (TriMesh *)Obj->Data;
+			Polys += T->FIndex;
+		}
+
+		for(O = GreetSc->OmniHead; O; O = O->Next)
+			Polys++;
+
+		FList = new Face * [Polys];
+		SList = new Face * [Polys];
+
+		View = GreetSc->CameraHead;
+
+		Ambient_Factor = 0.25;
+		Diffusive_Factor = 1.0;
+		Specular_Factor = 0.0;
+		Range_Factor = 1.0;
+		ImageSize = 0.25;
+
+		// this scene messes up at time zero
+		Timer++;
+
+		TTrd = Timer;
+		g_renderedPolys = 0;
+		FillerPixelcount = 0;
+	}
+
+	bool tick() override {
+		if (Keyboard[ScESC] || Timer >= CHPartTime) return false;
+
 		numFrames++;
 
-
-//		PROFILER: ZClear phase. also includes control keys handling
+		// PROFILER: ZClear phase. also includes control keys handling
 		Profiler[PROF_ZCLR] -= Timer;
 
-
-		if (Keyboard[ScTab])
-		{
+		if (Keyboard[ScTab]) {
 			if (View == &FC)
 				View = GreetSc->CameraHead;
 			else
 				View = &FC;
 		}
 
-		
-		dTime = Timer-TTrd;
+		dTime = Timer - TTrd;
 		// fast forward/rewind
-		if (Keyboard[ScF2])
-		{
+		if (Keyboard[ScF2]) {
 			Timer += dTime * 8;
 		}
-		if (Keyboard[ScF1])
-		{
+		if (Keyboard[ScF1]) {
 			if (dTime * 8 > Timer)
 				Timer = 0;
 			else
 				Timer -= dTime * 8;
 		}
-		static bool pause_mode = false;
 		if (Keyboard[ScP])
 			pause_mode = true;
 		if (Keyboard[ScU])
 			pause_mode = false;
-		if (pause_mode)
-		{
+		if (pause_mode) {
 			Timer = TTrd;
 		}
 		g_FrameTime = TTrd = Timer;
-		
+
 		// Clear Framebuffer and ZBuffer
-//		memset(VPage,0,PageSize + XRes*YRes*sizeof(word));
 		FastWrite(VPage, 0, (PageSize + XRes*YRes*sizeof(word)) >> 2);
 
-//		PROFILER: ANIM phase. also includes Dynamic Camera manager
+		// PROFILER: ANIM phase. also includes Dynamic Camera manager
 		Profiler[PROF_ANIM-1] += Timer;
 		Profiler[PROF_ANIM] -= Timer;
 
@@ -520,124 +506,98 @@ void Run_Greets()
 		Dynamic_Camera();
 		if (Keyboard[ScC]) {FC.ISource = View->ISource; Matrix_Copy(FC.Mat,View->Mat); FC.IFOV=View->IFOV;}
 
-
 		Animate_Objects(GreetSc);
 
-//		PROFILER: XFRM phase. 
+		// PROFILER: XFRM phase.
 		Profiler[PROF_XFRM-1] += Timer;
 		Profiler[PROF_XFRM] -= Timer;
 
 		Transform_Objects(GreetSc);
 
-//		PROFILER: LGHT phase. 
+		// PROFILER: LGHT phase.
 		Profiler[PROF_LGHT-1] += Timer;
 		Profiler[PROF_LGHT] -= Timer;
 
 		Lighting(GreetSc);
 
-//		PROFILER: SORT phase. 
+		// PROFILER: SORT phase.
 		Profiler[PROF_SORT-1] += Timer;
-		if (!CAll) continue;
+		if (!CAll) return true;
 		Profiler[PROF_SORT] -= Timer;
 
-		Radix_SortingASM(FList,SList,CAll);
+		Radix_SortingASM(FList, SList, CAll);
 
-//		PROFILER: RNDR phase. 
+		// PROFILER: RNDR phase.
 		Profiler[PROF_RNDR-1] += Timer;
 		Profiler[PROF_RNDR] -= Timer;
 
-
-        gg->Render();
+		gg->Render();
 		// reset per-frame zbuffer statistics
 		zPass = zReject = 0;
 		Render();
-//		memset(VPage,0,PageSize);
-//		MMXClear(VPage,PageSize);
-//		FillerPixelcount += XRes*YRes;
 
-//		PROFILER: FLIP phase. also contains display of runtime stats
+		// PROFILER: FLIP phase. also contains display of runtime stats
 		Profiler[PROF_FLIP-1] += Timer;
-		if (g_profilerActive)
-		{
+		if (g_profilerActive) {
 			// FPS printer
 			timerStack[timerIndex++] = Timer;
-			if (timerIndex==20) 
-			{
+			if (timerIndex == 20) {
 				timerIndex = 0;
-				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0/(float)(timerStack[19]-timerStack[timerIndex]));
 			} else {
-				snprintf(MSGStr, sizeof(MSGStr),"%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]) );
+				snprintf(MSGStr, sizeof(MSGStr), "%f FPS", 2000.0/(float)(timerStack[timerIndex-1]-timerStack[timerIndex]));
 			}
 			dword scroll = 0;
 			scroll = OutTextXY(VPage, 0, 0, MSGStr, 255);
 			snprintf(MSGStr, sizeof(MSGStr), "Frame %f", CurFrame);
-			scroll = OutTextXY(VPage,0, scroll+15,MSGStr,255);
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 			snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame", (int)(g_renderedPolys / numFrames));
 			scroll = OutTextXY(VPage, 0, scroll + 15, MSGStr, 255);
-			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/frame" , (int)(FillerPixelcount/(1000.0*numFrames)));
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
-			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second" , (int)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/frame", (int)(FillerPixelcount/(1000.0*numFrames)));
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
+			snprintf(MSGStr, sizeof(MSGStr), "%dK pixels/second", (int)(FillerPixelcount/1000.0 * 100.0 / Profiler[PROF_RNDR]));
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 
-	//		PROFILER: display stats	
-			for(i=0; i<PROF_NUM; i++)
-			{
-				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)" , ProfNames[i], ProfSample[i], ProfPerc[i]);
-				scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
+			for(int32_t i = 0; i < PROF_NUM; i++) {
+				snprintf(MSGStr, sizeof(MSGStr), "%s %3.1fms (%3.1f%%)", ProfNames[i], ProfSample[i], ProfPerc[i]);
+				scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 			}
 
-			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms" , ProfSum*10.0/ numFrames);
-			scroll = OutTextXY(VPage,0,scroll+15,MSGStr,255);
-
-	//		snprintf(MSGStr, sizeof(MSGStr), "%d percent Z-rejection", (int32_t) ( (float)zReject*100.0/ (zReject+zPass) ));
-	//		OutTextXY(VPage,0,45,MSGStr,255);
-	//		snprintf(MSGStr, sizeof(MSGStr), "%d polys/frame" , (int32_t)(g_renderedPolys / numFrames) );
-	//		OutTextXY(VPage,0,45,MSGStr,255);
-			// display messages.
-	/*		int32_t I, Y = -15;
-			for(I=0;I<10;I++)
-			if (MsgStr[I])
-			{
-				Y = OutTextXY(VPage,0,Y+15,MsgStr[I],255);
-				if (Timer>MsgClock[I]+150)
-				{
-					delete MsgStr[I];
-					MsgStr[I]=NULL;
-				}
-			}*/
+			snprintf(MSGStr, sizeof(MSGStr), "TOTL %3.1fms", ProfSum*10.0/numFrames);
+			scroll = OutTextXY(VPage, 0, scroll+15, MSGStr, 255);
 		}
 
 		Profiler[PROF_FLIP] -= Timer;
 
 		Flip(MainSurf);
-		//		PROFILER: frame finished
+		// PROFILER: frame finished
 		Profiler[PROF_FLIP] += Timer;
 
-//		PROFILER: Generate sample
+		// PROFILER: Generate sample
 		ProfSum = 0;
-		for(i=0; i<PROF_NUM; i++)
+		for(int32_t i = 0; i < PROF_NUM; i++)
 			ProfSum += Profiler[i];
-		for(i=0; i<PROF_NUM; i++)
-		{
-			ProfSample[i] =
-				Profiler[i]*10.0 / numFrames;
-			ProfPerc[i] = 
-				Profiler[i]*100.0/ProfSum;
+		for(int32_t i = 0; i < PROF_NUM; i++) {
+			ProfSample[i] = Profiler[i]*10.0 / numFrames;
+			ProfPerc[i] = Profiler[i]*100.0/ProfSum;
 		}
+		return true;
+	}
 
-	} Timer-=CHPartTime;
-//	if (Keyboard[ScESC])
-//	{
-//		#ifdef Play_Music
-//		ShutDown();
-//		#endif
-//		FDS_End();
-//		exit(-1);
-//	}
-	while (Keyboard[ScESC]) continue;
-	if (Timer<0) Timer = 0;
+	void cleanup() override {
+		Timer -= CHPartTime;
+		while (Keyboard[ScESC]) continue;
+		if (Timer < 0) Timer = 0;
 
-	delete [] FList;
-	delete [] SList;
-	Destroy_Scene(GreetSc);
+		delete [] FList;
+		delete [] SList;
+		Destroy_Scene(GreetSc);
+	}
+};
+} // anonymous namespace
+
+void Run_Greets()
+{
+	GreetsScene scene;
+	runSceneBlocking(scene);
 }

--- a/DEMO/GREETS.CPP
+++ b/DEMO/GREETS.CPP
@@ -5,6 +5,7 @@
 #include "MISC/PREPROC.H"
 #include "SceneTick.h"
 #include "Base/FDS_DECS.H"
+#include <memory>
 #include <vector>
 #include <VESA/Vesa.h>
 
@@ -408,6 +409,8 @@ void Initialize_Greets()
 namespace {
 struct GreetsScene : SceneDriver {
 	char MSGStr[128];
+	std::unique_ptr<Face*[]> fListStorage;
+	std::unique_ptr<Face*[]> sListStorage;
 	int32_t TTrd = 0;
 	int32_t timerStack[20] = {};
 	int32_t timerIndex = 0;
@@ -418,6 +421,8 @@ struct GreetsScene : SceneDriver {
 	const char *ProfNames[PROF_NUM] = {"ZCLR","ANIM","XFRM", "LGHT", "SORT", "RNDR", "FLIP"};
 	dword ProfSum = 0;
 	bool pause_mode = false;
+
+	~GreetsScene() override { Destroy_Scene(GreetSc); }
 
 	void init() override {
 		int32_t Polys = 0;
@@ -437,8 +442,10 @@ struct GreetsScene : SceneDriver {
 		for(O = GreetSc->OmniHead; O; O = O->Next)
 			Polys++;
 
-		FList = new Face * [Polys];
-		SList = new Face * [Polys];
+		fListStorage = std::make_unique<Face*[]>(Polys);
+		sListStorage = std::make_unique<Face*[]>(Polys);
+		FList = fListStorage.get();
+		SList = sListStorage.get();
 
 		View = GreetSc->CameraHead;
 
@@ -588,10 +595,6 @@ struct GreetsScene : SceneDriver {
 		Timer -= CHPartTime;
 		while (Keyboard[ScESC]) continue;
 		if (Timer < 0) Timer = 0;
-
-		delete [] FList;
-		delete [] SList;
-		Destroy_Scene(GreetSc);
 	}
 };
 } // anonymous namespace

--- a/DEMO/Glat.cpp
+++ b/DEMO/Glat.cpp
@@ -1,5 +1,6 @@
 #include "Rev.h"
 #include "IMGGENR/IMGGENR.H"
+#include "SceneTick.h"
 #include "VESA/Vesa.h"
 
 #include <algorithm>
@@ -210,59 +211,66 @@ static inline float max_magnitude(float a, float b)
 	if (fabs(a) > fabs(b)) return a; else return b;
 }
 
-void Run_Glato(void)
-{
-//	Setup_Grid_Texture_Mapper_XXX(XRes, YRes);
-//	Setup_Grid_Texture_Mapper_MMX(XRes, YRes);
-	int32_t xres = InitScreenXRes;
-	int32_t yres = InitScreenYRes;
-	Setup_Grid_Texture_Mapper_MMX(xres, yres);
+namespace {
+struct GlatoScene : SceneDriver {
+	int32_t xres = 0;
+	int32_t yres = 0;
+	float XResFactor = 0.0f;
+	float rXResFactor = 0.0f;
+	float rYResFactor = 0.0f;
 
-	XMMVector CameraPos(0,0,0);
+	XMMVector CameraPos{0, 0, 0};
 	XMMMatrix CamMat;
-	float Radius;
-	int x,y,i,j;
-	float a = 0.0f,bb = 0.0f,c = 0.0f,d = 0.0f,Delta = 0.0f,X1 = 0.0f,X2 = 0.0f,X3 = 0.0f,z = 0.0f,Rx = 0.0f,Ry = 0.0f,Rz = 0.0f;
-	float u,v,u1,v1,u2,v2,r,g,b;
-	float Code_R1,Code_RS,Code_R2,CCosR1,CSinR1,CCosR2,CSinR2;
-	float Gfx_R1,Gfx_R2,GCosR1,GSinR1,GCosR2,GSinR2,Gfx_RS;
-	XMMVector Intersection1,Origin1,Direction1,U;
-	
-	int X,Y;
-	float R1,R3,R4;
+	float Rx = 0.0f, Ry = 0.0f, Rz = 0.0f;
 
-	Radius = 1;
+	dword TTrd = 0;
+	int32_t timerStack[20] = {};
+	int32_t timerIndex = 0;
 
+	char MSGStr[MAX_GSTRING] = {};
 
-	int Gfx = 0,Sfx = 0, Code = 1;
-	float ST;
-	int32_t timerStack[20], timerIndex = 0;
-	for(i=0; i<20; i++)
-		timerStack[i] = Timer;
+	void init() override {
+		xres = InitScreenXRes;
+		yres = InitScreenYRes;
+		Setup_Grid_Texture_Mapper_MMX(xres, yres);
 
-	char MSGStr[MAX_GSTRING];
+		for(int i = 0; i < 20; i++)
+			timerStack[i] = Timer;
 
-	float XResFactor = xres/320.0;
-	float rXResFactor = 320.0/xres;
-	float rYResFactor = 240.0/yres;
+		XResFactor = xres / 320.0;
+		rXResFactor = 320.0 / xres;
+		rYResFactor = 240.0 / yres;
 
-	dword TTrd = Timer;
+		TTrd = Timer;
 
-	// clear the screen once (only yres % 8 last lines are really needed)
-	memset(FinalPage, 0, PageSize);
+		// clear the screen once (only yres % 8 last lines are really needed)
+		memset(FinalPage, 0, PageSize);
+	}
 
-	while (Timer<3500)
-	{
+	bool tick() override {
+		if (Timer >= 3500) return false;
+
+		int x, y, i, j;
+		float a = 0.0f, bb = 0.0f, c = 0.0f, d = 0.0f;
+		float X1 = 0.0f, X2 = 0.0f;
+		float u, v, u1, v1, u2, v2, r, g, b;
+		float Code_R1 = 0.0f, Code_RS = 0.0f, Code_R2;
+		float CCosR1, CSinR1, CCosR2, CSinR2;
+		float Gfx_R1, Gfx_R2, GCosR1, GSinR1, GCosR2, GSinR2, Gfx_RS = 0.0f;
+		XMMVector Intersection1, Origin1, Direction1, U;
+		int X, Y;
+		float Radius = 1;
+		int Gfx = 0, Sfx = 0, Code = 1;
+		float ST;
+
 		bool skip = false;
 		// fast forward/rewind
-		dTime = Timer-TTrd;		
-		if (Keyboard[ScF2])
-		{
+		dTime = Timer - TTrd;
+		if (Keyboard[ScF2]) {
 			skip = true;
 			Timer += dTime * 8;
 		}
-		if (Keyboard[ScF1])
-		{
+		if (Keyboard[ScF1]) {
 			skip = true;
 			if (dTime * 8 > Timer)
 				Timer = 0;
@@ -639,30 +647,30 @@ void Run_Glato(void)
 //		Flip(VSurface);
 		if (Keyboard[ScESC])
 			Timer = 1000000;
+		return true;
 	}
 
-	while (Keyboard[ScESC]) continue;
+	void cleanup() override {
+		while (Keyboard[ScESC]) continue;
 
-//	Timer -= 3500;
+		delete [] LenTable;
+		delete [] CosTable;
+		delete [] SinTable;
 
-///	if (Keyboard[ScESC])
-//	{
-//		#ifdef Play_Music
-///		ShutDown();
-//		#endif
-//		FDS_End();
-//		exit(-1);
-//	}
-	delete [] LenTable;
-	delete [] CosTable;
-	delete [] SinTable;
+		delete Plane_GP;
+		delete Code_GP;
+		delete Gfx_GP;
+		delete Sfx_GP;
+		_aligned_free(Page1);
+		_aligned_free(Page2);
+		_aligned_free(Page3);
+		_aligned_free(Page4);
+	}
+};
+} // anonymous namespace
 
-	delete Plane_GP;
-	delete Code_GP;
-	delete Gfx_GP;
-	delete Sfx_GP;
-	_aligned_free(Page1);
-	_aligned_free(Page2);
-	_aligned_free(Page3);
-	_aligned_free(Page4);
+void Run_Glato(void)
+{
+	GlatoScene scene;
+	runSceneBlocking(scene);
 }

--- a/DEMO/SceneTick.h
+++ b/DEMO/SceneTick.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Scene driver interface for the tick-based scene loop.
+//
+// Each scene is expressed as three phases:
+//   - init()    one-time setup (scene state, face lists, camera, factors)
+//   - tick()    one frame of work; returns true to keep going, false to stop
+//   - cleanup() one-time teardown (dealloc, Timer adjust, ESC-release wait)
+//
+// runSceneBlocking runs a driver to completion on the calling thread. The
+// Emscripten entry point will instead hand the driver to
+// emscripten_set_main_loop and call cleanup when tick returns false — the
+// SceneDriver shape stays the same.
+
+struct SceneDriver {
+    virtual ~SceneDriver() = default;
+    virtual void init() = 0;
+    virtual bool tick() = 0;
+    virtual void cleanup() = 0;
+};
+
+inline void runSceneBlocking(SceneDriver& driver) {
+    driver.init();
+    while (driver.tick()) continue;
+    driver.cleanup();
+}


### PR DESCRIPTION
## Summary
Each `Run_*` scene had a blocking `while (!Keyboard[ScESC] && Timer<XxPartTime)` loop that owned the frame cadence. This PR expresses every scene as a `SceneDriver` triple (`init` / `tick` / `cleanup`), so a future Emscripten port can drive the tick from `emscripten_set_main_loop` without rewriting scene bodies.

Per-scene local state that was previously loose in the function body — `TTrd`, `timerStack`/`Index`, profiler arrays, `pause_mode`, Fountain's `BPage` + `Blur`, City's `dispMap` + `backBuffer` — now lives as members of the driver struct. `FList`/`SList` (and Fountain's `BPage`) become `std::unique_ptr` members; `Destroy_Scene` runs from the destructor, so an exception between `init()` and `cleanup()` still releases cleanly.

Behaviour is intended to be bit-identical — the only control-flow reshapes are:
- `if (!CAll) continue;` → `return true;` (skip the rest of this tick, loop back)
- `goto norefl;` in `Run_Chase` / `Run_City` → `if (CAll) { ... }` block around the reflection sort+render

## Commit sequence (bisect-friendly)
1. Introduce `SceneDriver` interface + convert Run_Crash (pilot)
2. Convert Run_Greets
3. Convert Run_Chase
4. Convert Run_Fountain
5. Replace manual delete/Destroy_Scene with RAII in the four above
6. Convert Run_Glato
7. Convert Run_City

Net: -103 lines across 8 files.

`RunScene` in `RENDER.CPP` remains unreferenced; not addressed in this PR.

## Test plan
- [x] Clean build, macOS arm64
- [x] Manual playthrough confirms all six scenes (Glato / City / Chase / Fountain / Crash / Greets) render identically and control keys still work