### PR TITLE
Run the WASM port end-to-end with audio + GitHub Pages deploy

### DIFF
--- a/.github/workflows/wasm-pages.yml
+++ b/.github/workflows/wasm-pages.yml
@@ -1,0 +1,77 @@
+name: Build & deploy WASM demo to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache cargo target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            Modplayer/modplayer/target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('Modplayer/modplayer/**/Cargo.lock') }}
+
+      - name: Install Rust nightly + rust-src
+        run: |
+          rustup toolchain install nightly --component rust-src
+          rustup default nightly
+
+      - name: Setup emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 5.0.6
+          actions-cache-folder: emsdk-cache
+
+      - name: Install ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: Configure (emcmake)
+        run: emcmake cmake -S . -B build-wasm -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build-wasm
+
+      - name: Stage site
+        run: |
+          mkdir -p _site
+          cp build-wasm/DEMO/DEMO.html _site/index.html
+          cp build-wasm/DEMO/DEMO.js _site/
+          cp build-wasm/DEMO/DEMO.wasm _site/
+          cp build-wasm/DEMO/DEMO.data _site/
+          cp build-wasm/DEMO/coi-serviceworker.js _site/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,4 @@ DEMO.exe
 /Runtime/fountain-profiling.txt
 /libpng16/libpng16.lib
 /libpng16/zlib.lib
+/build-wasm/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Prerequisites:
 
 - **SDL2** discovered via `find_package(SDL2)`. On macOS: `brew install sdl2`.
 - **Rust toolchain** (`cargo` on PATH) — CMake invokes `cargo build` on the modplayer workspace automatically.
-- **Submodules** — the Rust workspace lives at `Modplayer/modplayer` as a submodule. Clone with `--recurse-submodules` or run `git submodule update --init --recursive` after checkout. Override with `-DMODPLAYER2_DIR=/path` to point at an external checkout (e.g. for cross-repo development).
+- **Submodules** — the Rust workspace lives at `Modplayer/modplayer` as a submodule. Clone with `--recurse-submodules` or run `git submodule update --init --recursive` after checkout. Override with `-DMODPLAYER_DIR=/path` to point at an external checkout (e.g. for cross-repo development).
 
 Stale/obsolete build trees that may still be on disk from pre-Tier-1 work (`CMake/`, `cmake-build-*`, `build.local/`) are gitignored — delete them freely.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ endif()
 
 if(EMSCRIPTEN)
     add_compile_options(-msimd128 -sUSE_SDL=2)
+    # The vendored Agner Fog vectorclass checks `EMSCRIPTEN` (no underscores)
+    # to skip x86-specific inline asm and __m128/__m128i/__m128d overloads
+    # that collapse when simde maps them all to the same wasm32 type. emcc
+    # only defines `__EMSCRIPTEN__` itself, so we define the plain form too.
+    add_compile_definitions(EMSCRIPTEN)
     if(APPLE)
         add_definitions(-DEMSCRIPTEN_MACOS=1)
     endif()

--- a/DEMO/CHASE.CPP
+++ b/DEMO/CHASE.CPP
@@ -5,6 +5,7 @@
 
 #include "CHASE.H"
 #include "SceneTick.h"
+#include "Scenes.h"
 #include <memory>
 
 #define FRONT_TO_BACK_SORTING
@@ -810,8 +811,13 @@ struct ChaseScene : SceneDriver {
 };
 } // anonymous namespace
 
+std::unique_ptr<SceneDriver> createChaseScene()
+{
+	return std::make_unique<ChaseScene>();
+}
+
 void Run_Chase()
 {
-	ChaseScene scene;
-	runSceneBlocking(scene);
+	auto scene = createChaseScene();
+	runSceneBlocking(*scene);
 }

--- a/DEMO/CITY.CPP
+++ b/DEMO/CITY.CPP
@@ -2,6 +2,7 @@
 #include "Rev.h"
 #include "CITY.H"
 #include "SceneTick.h"
+#include "Scenes.h"
 #include <algorithm>
 #include <memory>
 #include <vector>
@@ -2060,8 +2061,13 @@ struct CityScene : SceneDriver {
 };
 } // anonymous namespace
 
+std::unique_ptr<SceneDriver> createCityScene()
+{
+	return std::make_unique<CityScene>();
+}
+
 void Run_City()
 {
-	CityScene scene;
-	runSceneBlocking(scene);
+	auto scene = createCityScene();
+	runSceneBlocking(*scene);
 }

--- a/DEMO/CMakeLists.txt
+++ b/DEMO/CMakeLists.txt
@@ -59,15 +59,34 @@ if(EMSCRIPTEN)
     target_link_options(${PROJECT_NAME} PRIVATE
         -pthread
         -sPROXY_TO_PTHREAD=1
-        -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency
+        # Pool size: main-proxy + CodeEntry + nested init thread + ThreadPool
+        # render workers. navigator.hardwareConcurrency alone isn't enough;
+        # add headroom and allow on-demand creation above the pool.
+        -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency+4
+        # Emscripten's default pthread stack is 64KB which overflows during
+        # XM module parsing (and probably elsewhere — the engine wasn't
+        # written with such a tight stack in mind). Match a typical native
+        # default of ~4MB for both the proxy main thread and pthread workers.
+        -sSTACK_SIZE=4MB
+        -sDEFAULT_PTHREAD_STACK_SIZE=4MB
+        -sALLOW_BLOCKING_ON_MAIN_THREAD=1
         -sALLOW_MEMORY_GROWTH=1
         -sINITIAL_MEMORY=128MB
         -sASSERTIONS=1
         -sEXIT_RUNTIME=1
         -sUSE_SDL=2
         --preload-file "${CMAKE_SOURCE_DIR}/Runtime@/"
+        --shell-file "${CMAKE_CURRENT_SOURCE_DIR}/shell.html"
     )
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+
+    # Copy the COOP/COEP service worker next to the generated HTML so it's
+    # served at the same scope (needed when hosting on plain static servers
+    # like GitHub Pages that don't send the headers themselves).
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${CMAKE_CURRENT_SOURCE_DIR}/coi-serviceworker.js"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/coi-serviceworker.js")
 else()
     target_link_libraries(${PROJECT_NAME} PRIVATE
         FDS

--- a/DEMO/CMakeLists.txt
+++ b/DEMO/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(PROJECT_NAME DEMO)
 
-find_package(SDL2 REQUIRED)
+if(NOT EMSCRIPTEN)
+    find_package(SDL2 REQUIRED)
+endif()
 
 set(DEMO_SOURCES
     CHASE.CPP
@@ -41,10 +43,37 @@ add_executable(${PROJECT_NAME} ${DEMO_SOURCES})
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     SIMDE_ENABLE_NATIVE_ALIASES)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
-    FDS
-    Modplayer
-    SDL2::SDL2)
+if(EMSCRIPTEN)
+    # Emscripten brings its own SDL2 via -sUSE_SDL=2; don't require
+    # find_package(SDL2) on this target.
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        FDS
+        Modplayer)
 
-install(TARGETS ${PROJECT_NAME}
-        RUNTIME DESTINATION "${CMAKE_SOURCE_DIR}/Runtime")
+    # -pthread + PROXY_TO_PTHREAD: run main() on a pthread worker so the
+    # existing blocking patterns (ThreadPool condvar waits, SDL_WaitEvent)
+    # work unchanged without freezing the browser UI thread.
+    # --preload-file Runtime: embed the asset tree so the demo can read
+    # rev.cfg / SCENES / TEXTURES / FONTS relative to "/".
+    target_compile_options(${PROJECT_NAME} PRIVATE -pthread)
+    target_link_options(${PROJECT_NAME} PRIVATE
+        -pthread
+        -sPROXY_TO_PTHREAD=1
+        -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency
+        -sALLOW_MEMORY_GROWTH=1
+        -sINITIAL_MEMORY=128MB
+        -sASSERTIONS=1
+        -sEXIT_RUNTIME=1
+        -sUSE_SDL=2
+        --preload-file "${CMAKE_SOURCE_DIR}/Runtime@/"
+    )
+    set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        FDS
+        Modplayer
+        SDL2::SDL2)
+
+    install(TARGETS ${PROJECT_NAME}
+            RUNTIME DESTINATION "${CMAKE_SOURCE_DIR}/Runtime")
+endif()

--- a/DEMO/CMakeLists.txt
+++ b/DEMO/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DEMO_SOURCES
     Raytracer.h
     REV.CPP
     Rev.h
+    Scenes.h
     SceneTick.h
     SDL2.cpp
     SDL2.h)

--- a/DEMO/CRASH.CPP
+++ b/DEMO/CRASH.CPP
@@ -2,6 +2,7 @@
 
 #include "CRASH.H"
 #include "SceneTick.h"
+#include "Scenes.h"
 #include <memory>
 
 static Scene *CrashSc;
@@ -129,8 +130,13 @@ struct CrashScene : SceneDriver {
 };
 } // anonymous namespace
 
+std::unique_ptr<SceneDriver> createCrashScene()
+{
+	return std::make_unique<CrashScene>();
+}
+
 void Run_Crash()
 {
-	CrashScene scene;
-	runSceneBlocking(scene);
+	auto scene = createCrashScene();
+	runSceneBlocking(*scene);
 }

--- a/DEMO/FOUNTAIN.CPP
+++ b/DEMO/FOUNTAIN.CPP
@@ -1647,7 +1647,7 @@ Material VortexMat;
 void Load_Vortex()
 {
 	int32_t X,Y;
-	VorTexture.FileName = strdup("Textures/Vortex.JPG");
+	VorTexture.FileName = strdup("TEXTURES/VORTEX.JPG");
 	Identify_Texture(&VorTexture);
 	if (!VorTexture.BPP)
 	{

--- a/DEMO/FOUNTAIN.CPP
+++ b/DEMO/FOUNTAIN.CPP
@@ -6,6 +6,7 @@
 #include "FRUSTRUM.H"
 #include "Clipper.h"
 #include "SceneTick.h"
+#include "Scenes.h"
 #include <memory>
 
 static Scene *FntSc;
@@ -2018,8 +2019,13 @@ struct FountainScene : SceneDriver {
 };
 } // anonymous namespace
 
+std::unique_ptr<SceneDriver> createFountainScene()
+{
+	return std::make_unique<FountainScene>();
+}
+
 void Run_Fountain()
 {
-	FountainScene scene;
-	runSceneBlocking(scene);
+	auto scene = createFountainScene();
+	runSceneBlocking(*scene);
 }

--- a/DEMO/FillerTest.cpp
+++ b/DEMO/FillerTest.cpp
@@ -1178,7 +1178,7 @@ void FillerTest()
 	SetGBuffer(&gbuffer);
 
 //	Texture Tx;
-//	Tx.FileName = strdup("Textures/PBRK34.JPG");
+//	Tx.FileName = strdup("TEXTURES/PBRK34.JPG");
 //	Load_Texture(&Tx);
 //	BPPConvert_Texture(&Tx, 32);
 	// prepare texture

--- a/DEMO/GREETS.CPP
+++ b/DEMO/GREETS.CPP
@@ -4,6 +4,7 @@
 #include "FillerTest.h"
 #include "MISC/PREPROC.H"
 #include "SceneTick.h"
+#include "Scenes.h"
 #include "Base/FDS_DECS.H"
 #include <memory>
 #include <vector>
@@ -599,8 +600,13 @@ struct GreetsScene : SceneDriver {
 };
 } // anonymous namespace
 
+std::unique_ptr<SceneDriver> createGreetsScene()
+{
+	return std::make_unique<GreetsScene>();
+}
+
 void Run_Greets()
 {
-	GreetsScene scene;
-	runSceneBlocking(scene);
+	auto scene = createGreetsScene();
+	runSceneBlocking(*scene);
 }

--- a/DEMO/GREETS.CPP
+++ b/DEMO/GREETS.CPP
@@ -156,7 +156,7 @@ struct GreetsGenerator
 	{
 		Material *Mat;
 		for (Mat = MatLib; Mat->Next; Mat = Mat->Next) {
-			if (Mat->RelScene == GreetSc && Mat->Txtr && Mat->Txtr->FileName && !strcmp(Mat->Txtr->FileName, "Textures/p_text.jpg"))
+			if (Mat->RelScene == GreetSc && Mat->Txtr && Mat->Txtr->FileName && !strcmp(Mat->Txtr->FileName, "TEXTURES/P_TEXT.JPG"))
 			{
 				Mat->Txtr->Mipmap[0] = (byte *)OutBuf;
 				Mat->Txtr->Flags = Txtr_Nomip;
@@ -177,7 +177,7 @@ struct GreetsGenerator
 		ScaledBuf = (DWord*)_aligned_malloc(256 * 256 * 4, 16);
 
 
-		CodeTexture.FileName = strdup("Textures/Code.JPG");
+		CodeTexture.FileName = strdup("TEXTURES/CODE.JPG");
 		Identify_Texture(&CodeTexture);
 		if (!CodeTexture.BPP)
 		{

--- a/DEMO/Glat.cpp
+++ b/DEMO/Glat.cpp
@@ -80,10 +80,10 @@ void Initialize_Glato()
 	SfxTexture = new Texture;
 	SfxImage = new Image;
 
-	Load_Image_JPEG(LogoImage,"Textures/Logo.JPG");
+	Load_Image_JPEG(LogoImage,"TEXTURES/LOGO.JPG");
 	Scale_Image(LogoImage,xres,yres);
 
-/*	LogoTexture->FileName = strdup("Textures/Logo.JPG");
+/*	LogoTexture->FileName = strdup("TEXTURES/LOGO.JPG");
 	Identify_Texture(LogoTexture);
 	if (!LogoTexture->BPP)
 	{
@@ -95,7 +95,7 @@ void Initialize_Glato()
 	Convert_Texture2Image(LogoTexture,LogoImage);*/
 	
 
-	PlaneTexture->FileName = strdup("Textures/SC13.JPG");
+	PlaneTexture->FileName = strdup("TEXTURES/SC13.JPG");
 	Identify_Texture(PlaneTexture);
 	if (!PlaneTexture->BPP)
 	{
@@ -109,7 +109,7 @@ void Initialize_Glato()
 	//PlaneImage->Data[0] = 0x80808080;
 //	WOBPOINTSHEIGHT = 30;
 
-	CodeTexture->FileName = strdup("Textures/Code.JPG");
+	CodeTexture->FileName = strdup("TEXTURES/CODE.JPG");
 	Identify_Texture(CodeTexture);
 	if (!CodeTexture->BPP)
 	{
@@ -120,7 +120,7 @@ void Initialize_Glato()
 	Convert_Texture2Image(CodeTexture,CodeImage);
 
 
-	GfxTexture->FileName = strdup("Textures/Gfx.JPG");
+	GfxTexture->FileName = strdup("TEXTURES/GFX.JPG");
 	Identify_Texture(GfxTexture);
 	if (!GfxTexture->BPP)
 	{
@@ -130,7 +130,7 @@ void Initialize_Glato()
 	Load_Texture(GfxTexture);
 	Convert_Texture2Image(GfxTexture,GfxImage);
 
-	SfxTexture->FileName = strdup("Textures/Sfx.JPG");
+	SfxTexture->FileName = strdup("TEXTURES/SFX.JPG");
 	Identify_Texture(SfxTexture);
 	if (!SfxTexture->BPP)
 	{

--- a/DEMO/Glat.cpp
+++ b/DEMO/Glat.cpp
@@ -1,9 +1,11 @@
 #include "Rev.h"
 #include "IMGGENR/IMGGENR.H"
 #include "SceneTick.h"
+#include "Scenes.h"
 #include "VESA/Vesa.h"
 
 #include <algorithm>
+#include <memory>
 
 void Cross_Fade(byte *U1,byte *U2,byte *Target,int32_t Perc)
 {
@@ -669,8 +671,13 @@ struct GlatoScene : SceneDriver {
 };
 } // anonymous namespace
 
+std::unique_ptr<SceneDriver> createGlatoScene()
+{
+	return std::make_unique<GlatoScene>();
+}
+
 void Run_Glato(void)
 {
-	GlatoScene scene;
-	runSceneBlocking(scene);
+	auto scene = createGlatoScene();
+	runSceneBlocking(*scene);
 }

--- a/DEMO/ImageCompression.cpp
+++ b/DEMO/ImageCompression.cpp
@@ -2,7 +2,7 @@
 
 const float log2conv = 1.0 / log(2.0);
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
 inline float log2(float x) noexcept
 {
 	return log(x)*log2conv;

--- a/DEMO/REV.CPP
+++ b/DEMO/REV.CPP
@@ -467,9 +467,13 @@ material global ID or ptr
 #include "FILLERS/IX.h"
 #include "Threads.h"
 #include "../Modplayer/Modplayer.h"
+#include "SDL2.h"
 #include <SDL.h>
 #include <utility>
 #include <iostream>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 // global configuration db
 static ConfigurationDB *g_cfg;
@@ -983,11 +987,14 @@ void CodeEntry(void *var)
 
 	//dword sh = 0;
 	ModplayerHandle sh = 0;
+	fprintf(stderr, "[DEMO] g_playMusic=%u\n", (unsigned)g_playMusic);
 	if (g_playMusic)
 	{
 		//sh = FModLoadModule("Revival.XM");
 		//module.Load("Revival.xM");
-		sh = Modplayer_Create("Revival.xM");
+		fprintf(stderr, "[DEMO] before Modplayer_Create\n");
+		sh = Modplayer_Create("REVIVAL.XM");
+		fprintf(stderr, "[DEMO] after Modplayer_Create sh=%p\n", sh);
 	}
 	g_RevModuleHandle = sh;
 
@@ -1006,7 +1013,12 @@ void CodeEntry(void *var)
 	FPU_LPrecision();
 	if (g_playMusic)
 	{
+		fprintf(stderr, "[DEMO] before Modplayer_Start\n");
 		if (sh) Modplayer_Start(sh);
+		fprintf(stderr, "[DEMO] after Modplayer_Start\n");
+#ifdef __EMSCRIPTEN__
+		if (sh) SDL2_StartMusic(sh);
+#endif
 	}
 	Timer = 0;
 
@@ -1085,14 +1097,15 @@ void CodeEntry(void *var)
 
 	if (g_playMusic)
 	{
+#ifdef __EMSCRIPTEN__
+		SDL2_StopMusic();
+#endif
 		//if (sh) FModFreeModule(sh);
 		//FModClose();
 		//module.Stop();
 		if (sh) Modplayer_Stop(sh);
 	}
 }
-
-#include "SDL2.h"
 
 int main(int argc, const char *argv[])
 {
@@ -1105,7 +1118,7 @@ int main(int argc, const char *argv[])
 	g_demoYRes = cfg.extractInteger("ResolutionY");
 	g_fullScreenMode = cfg.extractInteger("FullScreenMode");
 
-    SDL_Init(SDL_INIT_VIDEO);
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
 
     SDL_Window * window = SDL_CreateWindow("",
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
@@ -1125,15 +1138,61 @@ int main(int argc, const char *argv[])
 		return -1;
 	}
 
+	fprintf(stderr, "[DEMO] before SDL2_InitDisplay\n");
 	SDL2_InitDisplay(window);
+	fprintf(stderr, "[DEMO] after SDL2_InitDisplay, MainSurf=%p\n", (void*)MainSurf);
 
 	memset(VPage, 0xcd, MainSurf->BPSL * YRes);
+	fprintf(stderr, "[DEMO] memset VPage done\n");
 	Flip(MainSurf);
+	fprintf(stderr, "[DEMO] first flip done\n");
 
 	TimerInit(100);
+	fprintf(stderr, "[DEMO] TimerInit done\n");
+	// Route stdout to logfile.txt; on Emscripten this goes to MEMFS and
+	// keeps the browser console quiet (our diagnostics use stderr).
 	freopen("logfile.txt", "w+", stdout);
 
+#ifdef __EMSCRIPTEN__
+	// Browsers require a user gesture before AudioContext can start. To keep
+	// audio in lockstep with scene playback, defer the entire demo (CodeEntry)
+	// until the first input event arrives. Show a hint overlay until then.
+	// PROXY_TO_PTHREAD: main() runs on a pthread worker with no DOM access,
+	// so dispatch DOM work to the browser main thread via MAIN_THREAD_EM_ASM.
+	MAIN_THREAD_EM_ASM({
+		var hint = document.createElement('div');
+		hint.id = 'rev-click-hint';
+		hint.textContent = 'Click or press any key to start';
+		hint.style.cssText =
+			'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);' +
+			'padding:1em 2em;background:rgba(0,0,0,0.75);color:#fff;' +
+			'font:18px/1.2 sans-serif;border-radius:4px;z-index:9999;' +
+			'pointer-events:none;';
+		document.body.appendChild(hint);
+	});
+	while (1) {
+		SDL_Event event;
+		SDL_WaitEvent(&event);
+		if (event.type == SDL_QUIT) {
+			SDL_Quit();
+			return 0;
+		}
+		if (event.type == SDL_KEYDOWN ||
+		    event.type == SDL_MOUSEBUTTONDOWN ||
+		    event.type == SDL_FINGERDOWN) {
+			break;
+		}
+	}
+	MAIN_THREAD_EM_ASM({
+		var h = document.getElementById('rev-click-hint');
+		if (h) h.remove();
+	});
+	fprintf(stderr, "[DEMO] user gesture observed, starting demo\n");
+#endif
+
+	fprintf(stderr, "[DEMO] spawning CodeEntry thread\n");
 	auto demoThread = std::thread(CodeEntry, nullptr);
+	fprintf(stderr, "[DEMO] CodeEntry thread spawned\n");
 
     while (1)
     {

--- a/DEMO/SDL2.cpp
+++ b/DEMO/SDL2.cpp
@@ -2,6 +2,11 @@
 #include <Base/FDS_DECS.H>
 #include <SDL.h>
 
+#ifdef __EMSCRIPTEN__
+#include "../Modplayer/Modplayer.h"
+#include <emscripten/threading.h>
+#endif
+
 
 static VESA_Surface SDL_MainSurf;
 static SDL_Window *sdl_window;
@@ -43,9 +48,19 @@ dword SDL2_InitDisplay(SDL_Window *window)
 	SDL_MainSurf.BPP = 32;
 
 	// Fill in the secondary surface VSurf structure
-	
+
 	// Create a renderer with V-Sync enabled.
+	// On Emscripten with PROXY_TO_PTHREAD, WebGL contexts can't be cleanly
+	// created from a pthread worker (the canvas gets transferred to the
+	// worker for offscreen rendering and becomes inaccessible to the main
+	// thread's GL init path). Force the software renderer there — the
+	// final frame is just an SDL_UpdateTexture + SDL_RenderCopy anyway, so
+	// CPU vs WebGL for that last step is a minor perf detail.
+#ifdef __EMSCRIPTEN__
+	SDL_Renderer * renderer = SDL_CreateRenderer(sdl_window, -1, SDL_RENDERER_SOFTWARE);
+#else
 	SDL_Renderer * renderer = SDL_CreateRenderer(sdl_window, -1, SDL_RENDERER_PRESENTVSYNC);
+#endif
 	SDL_MainSurf.Renderer = renderer;
 
 	V_Create(&SDL_MainSurf, renderer);
@@ -57,7 +72,64 @@ dword SDL2_InitDisplay(SDL_Window *window)
 	V_Flip(MainSurf);
 
 	FPU_LPrecision();
-	
+
 	return 0;
 }
+
+#ifdef __EMSCRIPTEN__
+static SDL_AudioDeviceID g_audio_dev = 0;
+static int g_audio_cb_count = 0;
+
+static void wasm_audio_callback(void* userdata, Uint8* stream, int len)
+{
+	if (g_audio_cb_count < 3) {
+		fprintf(stderr, "[AUDIO] callback #%d len=%d ud=%p\n",
+		        g_audio_cb_count, len, userdata);
+	}
+	g_audio_cb_count++;
+	// 512 frames × 2 channels × sizeof(float) = 4096 bytes per callback.
+	Modplayer_FillBuffer((ModplayerHandle)userdata,
+	                     reinterpret_cast<float*>(stream),
+	                     len / (2 * sizeof(float)));
+}
+
+// Runs on the browser main thread (proxied via emscripten_sync_run_in_main_runtime_thread).
+// SDL2's emscripten audio implementation references a JS-side `SDL2` global
+// that only exists in the main thread's JS context, so the open call must
+// happen there.
+static void open_audio_main_thread(void* modplayerHandle)
+{
+	SDL_AudioSpec want = {};
+	SDL_AudioSpec have = {};
+	want.freq = 48000;
+	want.format = AUDIO_F32SYS;
+	want.channels = 2;
+	want.samples = 512;  // matches xmplayer's AUDIO_BUF_FRAMES
+	want.callback = wasm_audio_callback;
+	want.userdata = modplayerHandle;
+	g_audio_dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+	fprintf(stderr, "[AUDIO] OpenAudioDevice -> dev=%u (err=%s)\n",
+	        (unsigned)g_audio_dev, g_audio_dev ? "ok" : SDL_GetError());
+	if (g_audio_dev) {
+		fprintf(stderr, "[AUDIO] have: freq=%d fmt=%04x ch=%d samples=%d\n",
+		        have.freq, have.format, have.channels, have.samples);
+		SDL_PauseAudioDevice(g_audio_dev, 0);
+		fprintf(stderr, "[AUDIO] device unpaused\n");
+	}
+}
+
+void SDL2_StartMusic(void* modplayerHandle)
+{
+	if (g_audio_dev || !modplayerHandle) return;
+	emscripten_sync_run_in_main_runtime_thread(
+		EM_FUNC_SIG_VI, &open_audio_main_thread, modplayerHandle);
+}
+
+void SDL2_StopMusic()
+{
+	if (!g_audio_dev) return;
+	SDL_CloseAudioDevice(g_audio_dev);
+	g_audio_dev = 0;
+}
+#endif
 

--- a/DEMO/SDL2.h
+++ b/DEMO/SDL2.h
@@ -9,5 +9,15 @@ dword SDL2_RemoveDisplay();
 
 void SDL2_Flip(VESA_Surface *VS);
 
+#ifdef __EMSCRIPTEN__
+// Emscripten music: the Rust modplayer-lib is built with the external-audio
+// feature (no Rust-side audio backend), so the host opens an SDL_AudioDevice
+// here and pulls samples via Modplayer_FillBuffer. The demo thread is gated
+// behind first user input so this call happens after a gesture and the
+// AudioContext can start.
+void SDL2_StartMusic(void* modplayerHandle);
+void SDL2_StopMusic();
+#endif
+
 
 #endif

--- a/DEMO/SceneTick.h
+++ b/DEMO/SceneTick.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+#include <vector>
+
 // Scene driver interface for the tick-based scene loop.
 //
 // Each scene is expressed as three phases:
@@ -7,10 +11,10 @@
 //   - tick()    one frame of work; returns true to keep going, false to stop
 //   - cleanup() one-time teardown (dealloc, Timer adjust, ESC-release wait)
 //
-// runSceneBlocking runs a driver to completion on the calling thread. The
-// Emscripten entry point will instead hand the driver to
-// emscripten_set_main_loop and call cleanup when tick returns false — the
-// SceneDriver shape stays the same.
+// runSceneBlocking runs a driver to completion on the calling thread.
+// SceneSequence walks a vector of scene factories one-at-a-time and is
+// itself tick-driven, so the same sequence can be run blocking on native
+// or driven frame-by-frame by emscripten_set_main_loop on WASM.
 
 struct SceneDriver {
     virtual ~SceneDriver() = default;
@@ -24,3 +28,39 @@ inline void runSceneBlocking(SceneDriver& driver) {
     while (driver.tick()) continue;
     driver.cleanup();
 }
+
+// Walks a list of scene factories. Each tick() advances the current scene
+// by one frame; when a scene's tick returns false, its cleanup runs and
+// the next scene is instantiated+initialized on the subsequent tick.
+// Returns false once all scenes have finished — a driver loop can use this
+// as its exit condition.
+struct SceneSequence {
+    using Factory = std::function<std::unique_ptr<SceneDriver>()>;
+
+    SceneSequence(std::vector<Factory> factories) : factories_(std::move(factories)) {}
+
+    bool tick() {
+        if (index_ >= factories_.size()) return false;
+
+        if (!current_) {
+            current_ = factories_[index_]();
+            current_->init();
+        }
+
+        if (!current_->tick()) {
+            current_->cleanup();
+            current_.reset();
+            ++index_;
+        }
+        return index_ < factories_.size();
+    }
+
+    void runBlocking() {
+        while (tick()) continue;
+    }
+
+private:
+    std::vector<Factory> factories_;
+    std::unique_ptr<SceneDriver> current_;
+    std::size_t index_ = 0;
+};

--- a/DEMO/Scenes.h
+++ b/DEMO/Scenes.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "SceneTick.h"
+#include <memory>
+
+// Factory functions for each playable scene. Each scene's SceneDriver
+// subclass lives in an anonymous namespace inside its .CPP; these
+// factories are the only way to construct one from outside.
+
+std::unique_ptr<SceneDriver> createGlatoScene();
+std::unique_ptr<SceneDriver> createCityScene();
+std::unique_ptr<SceneDriver> createChaseScene();
+std::unique_ptr<SceneDriver> createFountainScene();
+std::unique_ptr<SceneDriver> createCrashScene();
+std::unique_ptr<SceneDriver> createGreetsScene();

--- a/DEMO/coi-serviceworker.js
+++ b/DEMO/coi-serviceworker.js
@@ -1,0 +1,129 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp");
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => (typeof chrome !== "undefined" || typeof netscape !== "undefined") || coepDegrading,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+
+        if (n.serviceWorker && n.serviceWorker.controller) {
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: coi.coepCredentialless(),
+            });
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        if (window.crossOriginIsolated !== false || reloadedBySelf == "coiReloadInit") return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, due to insecure context.");
+            return;
+        }
+
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        if (!coi.shouldRegister()) return;
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "coiReloadInit");
+                    coi.doReload();
+                });
+
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "coiReloadInit");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                if (!coi.coepDegrade()) {
+                    !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+                    return;
+                }
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload();
+            }
+        );
+    })();
+}

--- a/DEMO/shell.html
+++ b/DEMO/shell.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <title>REVIVAL / FLOOD</title>
+    <style>
+      html, body { margin: 0; padding: 0; background: #000; color: #ccc;
+                   font: 14px/1.3 sans-serif; height: 100%; }
+      body { display: flex; flex-direction: column;
+             align-items: center; justify-content: center; }
+      #status { position: fixed; top: 0; left: 0; right: 0; padding: 6px 10px;
+                background: rgba(0,0,0,0.6); font-size: 12px;
+                pointer-events: none; }
+      #status.hidden { display: none; }
+      canvas { background: #000; display: block; image-rendering: pixelated; }
+    </style>
+  </head>
+  <body>
+    <!-- coi-serviceworker injects COOP/COEP headers so SharedArrayBuffer
+         (required for our pthread build) works on hosts like GitHub Pages
+         that don't support custom HTTP headers. No-op on emrun, which
+         already sets the headers itself. -->
+    <script src="coi-serviceworker.js"></script>
+    <div id="status">Downloading...</div>
+    <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
+    <script>
+      var statusEl = document.getElementById('status');
+      var canvasEl = document.getElementById('canvas');
+      function setStatus(text) {
+        if (!text) { statusEl.classList.add('hidden'); return; }
+        statusEl.classList.remove('hidden');
+        statusEl.textContent = text;
+      }
+      var Module = {
+        canvas: canvasEl,
+        setStatus: setStatus,
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          setStatus(left
+            ? 'Loading... (' + (this.totalDependencies - left) + '/' + this.totalDependencies + ')'
+            : '');
+        }
+      };
+      setStatus('Downloading...');
+      window.onerror = function() {
+        setStatus('Exception thrown, see console');
+        setStatus = function(t) { if (t) console.error('[post-exception] ' + t); };
+      };
+    </script>
+    {{{ SCRIPT }}}
+  </body>
+</html>

--- a/FDS/Base/FDS_DEFS.H
+++ b/FDS/Base/FDS_DEFS.H
@@ -14,7 +14,7 @@
 
 #define MAX_GSTRING 128
 
-#if defined(__APPLE__) || defined(EMSCRIPTEN_MACOS)
+#if defined(__APPLE__) || defined(EMSCRIPTEN_MACOS) || defined(__EMSCRIPTEN__)
 #define _strdup strdup
 //#define _aligned_malloc aligned_alloc
 #define _aligned_malloc(a,b) malloc(a)

--- a/FDS/CMakeLists.txt
+++ b/FDS/CMakeLists.txt
@@ -186,3 +186,9 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
     _LIB
     _MBCS
     SIMDE_ENABLE_NATIVE_ALIASES)
+
+if(EMSCRIPTEN)
+    # std::thread / mutex / condition_variable need -pthread at compile time
+    # for the PROXY_TO_PTHREAD mode we use in DEMO.
+    target_compile_options(${PROJECT_NAME} PUBLIC -pthread)
+endif()

--- a/FDS/FLD/FLD_MAT.CPP
+++ b/FDS/FLD/FLD_MAT.CPP
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 //#include <conio.h>
 #include <string.h>
+#include <ctype.h>
 #include <math.h>
 
 #include "Base/FDS_DEFS.H"
@@ -44,8 +45,12 @@ void AddMaterial(FldMat *OrgMat, Scene *SceneGroup)
 	CurMat->RelScene=SceneGroup;
 	if (!(*OrgMat->TextureImage)) return;
 	Image=new char[strlen(OrgMat->TextureImage) + 15];
-	strcpy(Image,"Textures/");
+	strcpy(Image,"TEXTURES/");
 	strcat(Image,OrgMat->TextureImage);
+#ifdef __EMSCRIPTEN__
+	// Emscripten's MEMFS is case-sensitive; runtime assets are uppercase.
+	for (char *p = Image + 9; *p; ++p) *p = (char)toupper((unsigned char)*p);
+#endif
 	for (Temp=MatLib;Temp!=CurMat;Temp=Temp->Next)
 	{
 		if (Temp->RelScene!=SceneGroup) continue;

--- a/FDS/MISC/PREPROC.CPP
+++ b/FDS/MISC/PREPROC.CPP
@@ -613,7 +613,7 @@ void Init_Flare_Textures(Scene *Sc)
 		//    printf("<PR:IFT>: Assigning new material to Group %d.\n",M->Group);
 		M->Name = strdup("Default Flare material");
 		M->Txtr = new Texture;
-		M->Txtr->FileName = strdup ("Textures/Flare.GIF");
+		M->Txtr->FileName = strdup ("TEXTURES/Flare.GIF");
 		Identify_Texture(M->Txtr);
 		
 		//    if (!M->Txtr->BPP) printf("<PR:IFT>: Identification Failure for Texture %s at Material %s.\n",M->Txtr->FileName,M->Name); else printf("<PR:IFT>: Texture %s was Identified correctly\n         for Material %s as a %d BPP image file.\n",M->Txtr->FileName,M->Name,M->Txtr->BPP);
@@ -658,7 +658,7 @@ void Init_Flare_Textures(Scene *Sc)
 		M->Next = M->Prev = NULL;
 		}
 		strcpy(M->Name,O->Name);
-		strcpy(S,"Textures/");
+		strcpy(S,"TEXTURES/");
 		strcat(S,O->Name);
 		M->Txtr->FileName = strdup(S);
 		Identify_Texture(M->Txtr);
@@ -737,7 +737,7 @@ void Default_Texture(Scene *Sc)
 			Convert_Image2Texture(&Plasma,M->Txtr);
 			M->Flags = Mat_Nonconv | Mat_RGBInterp;*/
 			
-			M->Txtr->FileName = strdup("Textures/Default.GIF");
+			M->Txtr->FileName = strdup("TEXTURES/Default.GIF");
 			M->Txtr->BPP=0;
 			Load_Texture(M->Txtr);
 			if (!M->Txtr->BPP) {delete M->Txtr; M->Txtr=NULL;}

--- a/FDS/RENDER/GENERAL.H
+++ b/FDS/RENDER/GENERAL.H
@@ -119,7 +119,7 @@ char FDS_Init(unsigned short x,unsigned short y,unsigned char bpp)
 
 	// read std. font from AFT file.
 	printf("] Basic font.\n");
-	Font1=LoadAFT("Fonts/Standard.AFT");
+	Font1=LoadAFT("FONTS/STANDARD.AFT");
 	Active_Font = Font1;
 
 	printf("] Initializing Video system.\n");

--- a/FDS/SkyCube/SkyCube.cpp
+++ b/FDS/SkyCube/SkyCube.cpp
@@ -180,7 +180,7 @@ Scene * CreateSkyCube(dword skyType)
 	Material *M[6];
 	Texture *Tx[6];
 
-	const char* names[6] = { "Textures/SBBK.JPG", "Textures/SBRT.JPG", "Textures/SBFT.JPG", "Textures/SBLF.JPG", "Textures/SBDN.JPG", "Textures/SBUP.JPG" };
+	const char* names[6] = { "TEXTURES/SBBK.JPG", "TEXTURES/SBRT.JPG", "TEXTURES/SBFT.JPG", "TEXTURES/SBLF.JPG", "TEXTURES/SBDN.JPG", "TEXTURES/SBUP.JPG" };
 
 	//DWord* TempBuf = new DWord[65536];
 	for (i = 0; i < 6; i++)

--- a/Modplayer/CMakeLists.txt
+++ b/Modplayer/CMakeLists.txt
@@ -14,6 +14,15 @@ if(NOT EXISTS "${MODPLAYER2_DIR}/Cargo.toml")
         "checkout.")
 endif()
 
+if(EMSCRIPTEN)
+    # Music is stubbed out in the Emscripten build (see Modplayer.h) — skip
+    # the Rust build entirely. The stubs are inline in the header, so the
+    # INTERFACE target just needs to propagate the include directory.
+    add_library(${PROJECT_NAME} INTERFACE)
+    target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+    return()
+endif()
+
 find_program(CARGO_EXECUTABLE cargo REQUIRED)
 
 # Rust profile: release unless the user asked for a debug CMake build.

--- a/Modplayer/CMakeLists.txt
+++ b/Modplayer/CMakeLists.txt
@@ -1,26 +1,17 @@
 set(PROJECT_NAME Modplayer)
 
 # The heavy lifting is in a Rust workspace tracked as a git submodule at
-# Modplayer/modplayer-2. Override with -DMODPLAYER2_DIR=... to point at a
+# Modplayer/modplayer. Override with -DMODPLAYER_DIR=... to point at a
 # sibling checkout instead (useful for cross-repo development).
-set(MODPLAYER2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/modplayer" CACHE PATH
-    "Path to the modplayer-2 Rust workspace")
+set(MODPLAYER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/modplayer" CACHE PATH
+    "Path to the modplayer Rust workspace")
 
-if(NOT EXISTS "${MODPLAYER2_DIR}/Cargo.toml")
+if(NOT EXISTS "${MODPLAYER_DIR}/Cargo.toml")
     message(FATAL_ERROR
-        "modplayer-2 not found at '${MODPLAYER2_DIR}'.\n"
+        "modplayer not found at '${MODPLAYER_DIR}'.\n"
         "Run `git submodule update --init --recursive` from the repo root, "
-        "or pass -DMODPLAYER2_DIR=/path/to/modplayer-2 to point at a sibling "
+        "or pass -DMODPLAYER_DIR=/path/to/modplayer to point at a sibling "
         "checkout.")
-endif()
-
-if(EMSCRIPTEN)
-    # Music is stubbed out in the Emscripten build (see Modplayer.h) — skip
-    # the Rust build entirely. The stubs are inline in the header, so the
-    # INTERFACE target just needs to propagate the include directory.
-    add_library(${PROJECT_NAME} INTERFACE)
-    target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-    return()
 endif()
 
 find_program(CARGO_EXECUTABLE cargo REQUIRED)
@@ -34,18 +25,49 @@ else()
     set(_cargo_profile_dir "release")
 endif()
 
-set(_modplayer_rust_lib
-    "${MODPLAYER2_DIR}/target/${_cargo_profile_dir}/libmodplayer.a")
+# On Emscripten the bundled sdl2 crate collides with emcc's -sUSE_SDL=2,
+# so we build with --no-default-features --features external-audio. The C++
+# side opens its own SDL_AudioDevice and pulls samples via Modplayer_FillBuffer.
+if(EMSCRIPTEN)
+    set(_cargo_target_flag --target wasm32-unknown-emscripten)
+    set(_cargo_features_flag --no-default-features --features external-audio)
+    set(_modplayer_rust_lib
+        "${MODPLAYER_DIR}/target/wasm32-unknown-emscripten/${_cargo_profile_dir}/libmodplayer.a")
+else()
+    set(_cargo_target_flag "")
+    set(_cargo_features_flag "")
+    set(_modplayer_rust_lib
+        "${MODPLAYER_DIR}/target/${_cargo_profile_dir}/libmodplayer.a")
+endif()
 
-add_custom_command(
-    OUTPUT "${_modplayer_rust_lib}"
-    # CMAKE_POLICY_VERSION_MINIMUM=3.5 lets the vendored sdl2-sys build under
-    # CMake >= 4.0, which dropped compatibility with its older cmake_minimum_required.
-    COMMAND ${CMAKE_COMMAND} -E env CMAKE_POLICY_VERSION_MINIMUM=3.5
-            "${CARGO_EXECUTABLE}" build ${_cargo_profile_flag} --package modplayer-lib
-    WORKING_DIRECTORY "${MODPLAYER2_DIR}"
-    COMMENT "Building modplayer-2 (Rust, ${_cargo_profile_dir})"
-    USES_TERMINAL)
+if(EMSCRIPTEN)
+    # The C++ side links with -pthread (--shared-memory). Rust objects must be
+    # built with the matching wasm features, otherwise wasm-ld rejects them.
+    # Rebuild std too (-Z build-std) so its objects also carry +atomics.
+    add_custom_command(
+        OUTPUT "${_modplayer_rust_lib}"
+        COMMAND ${CMAKE_COMMAND} -E env
+                CMAKE_POLICY_VERSION_MINIMUM=3.5
+                "RUSTFLAGS=-C target-feature=+atomics,+bulk-memory"
+                "${CARGO_EXECUTABLE}" build ${_cargo_profile_flag}
+                ${_cargo_target_flag} ${_cargo_features_flag}
+                -Z build-std=std,panic_abort
+                --package modplayer-lib
+        WORKING_DIRECTORY "${MODPLAYER_DIR}"
+        COMMENT "Building modplayer (Rust wasm, ${_cargo_profile_dir})"
+        USES_TERMINAL)
+else()
+    add_custom_command(
+        OUTPUT "${_modplayer_rust_lib}"
+        # CMAKE_POLICY_VERSION_MINIMUM=3.5 lets the vendored sdl2-sys build under
+        # CMake >= 4.0, which dropped compatibility with its older cmake_minimum_required.
+        COMMAND ${CMAKE_COMMAND} -E env CMAKE_POLICY_VERSION_MINIMUM=3.5
+                "${CARGO_EXECUTABLE}" build ${_cargo_profile_flag}
+                --package modplayer-lib
+        WORKING_DIRECTORY "${MODPLAYER_DIR}"
+        COMMENT "Building modplayer (Rust, ${_cargo_profile_dir})"
+        USES_TERMINAL)
+endif()
 
 add_custom_target(modplayer_rust_build DEPENDS "${_modplayer_rust_lib}")
 

--- a/Modplayer/Modplayer.h
+++ b/Modplayer/Modplayer.h
@@ -1,7 +1,12 @@
 #pragma once
 typedef void *ModplayerHandle;
 
-#if 0 /* || _WIN64 */
+// Emscripten build stubs music out for now. The Rust modplayer-lib does
+// cross-compile to wasm32-unknown-emscripten, but its sdl2 crate bundles
+// its own SDL2 which collides with emcc's -sUSE_SDL=2 at link time.
+// TODO(wasm): either strip the bundled SDL from the wasm rust build or
+// replace the audio shim with a direct Emscripten audio backend.
+#if defined(__EMSCRIPTEN__)
 inline ModplayerHandle Modplayer_Create(const char* path) { return 0; }
 inline void Modplayer_Start(ModplayerHandle handle) {}
 inline void Modplayer_Stop(ModplayerHandle handle) {}
@@ -14,4 +19,4 @@ extern "C" {
 	void Modplayer_Stop(ModplayerHandle handle);
 	void Modplayer_SetOrder(ModplayerHandle handle, unsigned int order);
 }
-#endif // DEBUG
+#endif

--- a/Modplayer/Modplayer.h
+++ b/Modplayer/Modplayer.h
@@ -1,22 +1,17 @@
 #pragma once
 typedef void *ModplayerHandle;
 
-// Emscripten build stubs music out for now. The Rust modplayer-lib does
-// cross-compile to wasm32-unknown-emscripten, but its sdl2 crate bundles
-// its own SDL2 which collides with emcc's -sUSE_SDL=2 at link time.
-// TODO(wasm): either strip the bundled SDL from the wasm rust build or
-// replace the audio shim with a direct Emscripten audio backend.
-#if defined(__EMSCRIPTEN__)
-inline ModplayerHandle Modplayer_Create(const char* path) { return 0; }
-inline void Modplayer_Start(ModplayerHandle handle) {}
-inline void Modplayer_Stop(ModplayerHandle handle) {}
-inline void Modplayer_SetOrder(ModplayerHandle handle, unsigned int order) {}
-
-#else
 extern "C" {
 	ModplayerHandle Modplayer_Create(const char* path);
 	void Modplayer_Start(ModplayerHandle handle);
 	void Modplayer_Stop(ModplayerHandle handle);
 	void Modplayer_SetOrder(ModplayerHandle handle, unsigned int order);
-}
+
+#if defined(__EMSCRIPTEN__)
+	// external-audio backend: host opens its own audio device (SDL_AudioDevice
+	// in our case) and pulls samples via this entry point. `frames` must be
+	// AUDIO_BUF_FRAMES (512) and `out` receives `frames * 2` interleaved
+	// stereo f32s.
+	void Modplayer_FillBuffer(ModplayerHandle handle, float* out, unsigned int frames);
 #endif
+}


### PR DESCRIPTION
## Summary
- Brings the emscripten port from \"links\" to \"runs the demo with music\" in the browser.
- Adds GitHub Actions workflow that builds the WASM target and publishes to GitHub Pages.

## What's in here
- **Audio**: Rust modplayer-lib uses the new `external-audio` feature (PR Gil-AdB/modplayer#15). C++ side opens an SDL_AudioDevice and pulls samples via `Modplayer_FillBuffer`. The open call is dispatched to the main runtime thread (SDL2's emscripten audio references a JS global that only exists in the main thread's JS context).
- **Threading**: pthread stack bumped to 4 MB (default 64 KB overflows during XM parse). Rust std rebuilt with `+atomics,+bulk-memory` so wasm-ld accepts shared-memory linkage.
- **Autoplay sync**: defer CodeEntry spawn until first user gesture so audio can start in lockstep with scenes. \"Click to start\" overlay rendered via DOM, dispatched via `MAIN_THREAD_EM_ASM` (worker has no `document`).
- **Shell**: custom minimal HTML shell, no emscripten branding.
- **Filesystem**: case-correction for emscripten's case-sensitive MEMFS — hard-coded texture/font paths in scenes plus a defensive uppercase pass on FLD-loaded texture names.
- **Renames**: `MODPLAYER2_DIR` → `MODPLAYER_DIR` (was a stale name from a parallel modplayer effort).

## GitHub Pages
- `coi-serviceworker.js` vendored next to the shell so SharedArrayBuffer works on hosts that don't set COOP/COEP headers themselves.
- `.github/workflows/wasm-pages.yml` builds with emscripten + nightly Rust + `-Z build-std`, then deploys to Pages on push to `master`.

## Test plan
- [x] Native macOS build still links and runs
- [x] WASM build links cleanly
- [x] Demo runs in browser through full scene sequence (Glato → City → ...)
- [x] Music plays in sync after click-to-start overlay
- [ ] Pages workflow runs successfully on first deploy after merge

## Follow-ups
- Right edge of polygons missing under wasm SIMD (rasterizer fill convention) — separate investigation
- Fullscreen toggle isn't wired up in code (cfg variable read but never applied)
- The Rust submodule has lots of `dbg!()` macros that pollute the console on first load (xmplayer); worth a cleanup pass upstream