### PR TITLE
Fix wasm rasterizer seams + SDL→legacy keyboard mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,6 +306,7 @@ DEMO.exe
 /libpng
 /Runtime/logfile.txt
 /Runtime/fountain-profiling.txt
+/Runtime/snapshots/
 /libpng16/libpng16.lib
 /libpng16/zlib.lib
 /build-wasm/

--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,7 @@ DEMO.exe
 /Runtime/fountain-profiling.txt
 /Runtime/snapshots/
 /Runtime/snapshots-*/
+/Runtime/glat-*/
 /libpng16/libpng16.lib
 /libpng16/zlib.lib
 /build-wasm/

--- a/.gitignore
+++ b/.gitignore
@@ -307,6 +307,7 @@ DEMO.exe
 /Runtime/logfile.txt
 /Runtime/fountain-profiling.txt
 /Runtime/snapshots/
+/Runtime/snapshots-*/
 /libpng16/libpng16.lib
 /libpng16/zlib.lib
 /build-wasm/

--- a/DEMO/CITY.CPP
+++ b/DEMO/CITY.CPP
@@ -2066,6 +2066,11 @@ std::unique_ptr<SceneDriver> createCityScene()
 	return std::make_unique<CityScene>();
 }
 
+int32_t getCityCTPartTime()
+{
+	return CTPartTime;
+}
+
 void Run_City()
 {
 	auto scene = createCityScene();

--- a/DEMO/CITY.H
+++ b/DEMO/CITY.H
@@ -1,2 +1,9 @@
 // definitions, constants, etc
 //#define CITY_RAIN
+
+#include <cstdint>
+
+// Total Timer ticks the City scene plays for; tick() returns false once
+// Timer reaches this. Exposed so the snapshot harness can pick valid
+// Timer values without having to recompute the formula.
+int32_t getCityCTPartTime();

--- a/DEMO/CMakeLists.txt
+++ b/DEMO/CMakeLists.txt
@@ -34,7 +34,9 @@ set(DEMO_SOURCES
     Scenes.h
     SceneTick.h
     SDL2.cpp
-    SDL2.h)
+    SDL2.h
+    Snapshot.cpp
+    Snapshot.h)
 
 source_group("" FILES ${DEMO_SOURCES})
 

--- a/DEMO/CMakeLists.txt
+++ b/DEMO/CMakeLists.txt
@@ -89,6 +89,37 @@ if(EMSCRIPTEN)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${CMAKE_CURRENT_SOURCE_DIR}/coi-serviceworker.js"
                 "$<TARGET_FILE_DIR:${PROJECT_NAME}>/coi-serviceworker.js")
+
+    # Headless wasm snapshot binary, runs under node:
+    #   cd Runtime && node ../build-wasm/DEMO/DEMO_snapshot.js \
+    #     --snapshot=city --out=snapshots
+    # Same source as DEMO but stripped of browser-only scaffolding so it
+    # exits cleanly after the snapshot path returns from main().
+    add_executable(DEMO_snapshot ${DEMO_SOURCES})
+    target_compile_definitions(DEMO_snapshot PRIVATE
+        SIMDE_ENABLE_NATIVE_ALIASES)
+    target_link_libraries(DEMO_snapshot PRIVATE
+        FDS
+        Modplayer)
+    target_compile_options(DEMO_snapshot PRIVATE -pthread)
+    target_link_options(DEMO_snapshot PRIVATE
+        -pthread
+        -sENVIRONMENT=node
+        # NODERAWFS gives fopen() direct access to the host filesystem so
+        # PPM/PGM/CSV outputs land on disk and the demo's relative-path
+        # asset loads (rev.cfg, SCENES/, ...) work when run from Runtime/.
+        -sNODERAWFS=1
+        -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency+4
+        -sSTACK_SIZE=4MB
+        -sDEFAULT_PTHREAD_STACK_SIZE=4MB
+        -sALLOW_BLOCKING_ON_MAIN_THREAD=1
+        -sALLOW_MEMORY_GROWTH=1
+        -sINITIAL_MEMORY=128MB
+        -sASSERTIONS=1
+        -sEXIT_RUNTIME=1
+        -sUSE_SDL=2
+    )
+    set_target_properties(DEMO_snapshot PROPERTIES SUFFIX ".js")
 else()
     target_link_libraries(${PROJECT_NAME} PRIVATE
         FDS

--- a/DEMO/FillerTest.cpp
+++ b/DEMO/FillerTest.cpp
@@ -1305,3 +1305,133 @@ void FillerTest()
 
 	delete [] l_TestTexture;
 }
+
+// -----------------------------------------------------------------------------
+// Snapshot harness entry points. Mirrors the relevant parts of FillerTest()'s
+// setup but skips the loop / FPS overlay / Mekalele path; the renderer is
+// pinned to TheOtherBarry so we can isolate the rasterizer-edge / mask
+// behaviour under wasm-vs-native diff.
+
+static Scene s_snapshotScene;
+static Material* s_snapshotGradient = nullptr;
+
+static void drawPolyOtherBarry(float T_in, float DT)
+{
+	Vertex V[4];
+	Face F;
+
+	float a = (T_in + DT) * 0.003f;
+	float c = cosf(a);
+	float s = sinf(a);
+
+	const auto W = 280;
+	const auto H = 250;
+
+	V[0].PX = 900.1f - W * c - H * s;
+	V[0].PY = 400.1f + W * s - H * c;
+	V[0].TPos.z = 1.0f;
+	V[0].U = -1.0f / 512.0f;
+	V[0].V = -1.0f / 512.0f;
+
+	V[1].PX = 900.1f + W * c - H * s;
+	V[1].PY = 400.1f - W * s - H * c;
+	V[1].TPos.z = 1.0f;
+	V[1].U = 511.0f / 512.0f;
+	V[1].V = -1.0f / 512.0f;
+
+	V[2].PX = 900.1f + W * c + H * s;
+	V[2].PY = 400.1f - W * s + H * c;
+	V[2].TPos.z = 1.0f;
+	V[2].U = 511.0f / 512.0f;
+	V[2].V = 511.0f / 512.0f;
+
+	V[3].PX = 900.1f - W * c + H * s;
+	V[3].PY = 400.1f + W * s + H * c;
+	V[3].TPos.z = 1.0f;
+	V[3].U = -1.0f / 512.0f;
+	V[3].V = 511.0f / 512.0f;
+
+	for (int i = 0; i < 4; i++) {
+		V[i].LR = V[i].LG = V[i].LB = V[i].LA = 255;
+	}
+
+	F.Txtr = &DummyMat;
+	DummyMat.Txtr = &DummyTex;
+	DummyTex.Data = (byte*)l_TestTexture;
+	DummyTex.Mipmap[0] = DummyTex.Data;
+	DummyTex.LSizeX = 8;
+	DummyTex.LSizeY = 8;
+	F.Txtr->ZBufferWrite = 0;
+	F.Filler = TheOtherBarry<barry::TBlendMode::OVERWRITE, barry::TTextureMode::NORMAL>;
+
+	Viewport vp;
+	vp.ClipX1 = 0;
+	vp.ClipX2 = XRes;
+	vp.ClipY1 = 0;
+	vp.ClipY2 = YRes_1;
+
+	for (int i = 0; i < 4; i++) {
+		V[i].RZ = 1.0f / V[i].TPos.z;
+		V[i].UZ = V[i].U * V[i].RZ;
+		V[i].VZ = V[i].V * V[i].RZ;
+		viewportCalcFlags(vp, &V[i]);
+	}
+
+	counter = 0;
+	ThreadPool::instance().enqueue([&F, &vp, V = &V[0]]() {
+		F.A = &V[0]; F.B = &V[1]; F.C = &V[2];
+		_2DClipper::getInstance()->clip(vp, F);
+
+		F.A = &V[0]; F.B = &V[2]; F.C = &V[3];
+		_2DClipper::getInstance()->clip(vp, F);
+
+		std::unique_lock<std::mutex> lock(mut);
+		++counter;
+		cv.notify_one();
+	});
+
+	{
+		std::unique_lock<std::mutex> lock(mut);
+		cv.wait(lock, [] { return counter == 1; });
+	}
+}
+
+void FillerTestSnapshotInit(int /*xres*/, int /*yres*/)
+{
+	CurScene = &s_snapshotScene;
+	s_snapshotScene.Flags = 0;
+	s_snapshotScene.NZP = 0.5f;
+	s_snapshotScene.FZP = 1000.0f;
+
+	std::vector<GradientEndpoint> endpoints;
+	endpoints.emplace_back(0,    Color{ 0.0, 0.0, 0.0, 0.2 });
+	endpoints.emplace_back(0.5,  Color{ 0.3, 0.0, 0.1, 0.2 });
+	endpoints.emplace_back(0.6,  Color{ 1.0, 0.0, 0.1, 0.2 });
+	endpoints.emplace_back(0.75, Color{ 1.0, 0.4, 0.8, 0.2 });
+	endpoints.emplace_back(0.8,  Color{ 1.0, 1.0, 1.0, 0.2 });
+	endpoints.emplace_back(1.0,  Color{ 1.0, 1.0, 1.0, 0.2 });
+
+	s_snapshotGradient = Generate_Gradient(endpoints, 256, 0.2, false);
+	l_TestTexture = (DWord*)s_snapshotGradient->Txtr->Data;
+
+	for (dword j = 0; j < 256; ++j) {
+		for (dword i = 0; i < 256; ++i) {
+			l_TestTexture[i + (j << 8)] = 0xFFFFFF;
+		}
+	}
+	Sachletz(l_TestTexture, 256, 256);
+	s_snapshotGradient->Txtr->Flags = Txtr_Tiled | Txtr_Nomip;
+}
+
+void FillerTestSnapshotRender(int32_t seed)
+{
+	const std::size_t zSize = sizeof(word) * static_cast<std::size_t>(XRes) * YRes;
+	memset(VPage, 0, PageSize + zSize);
+	drawPolyOtherBarry(static_cast<float>(seed) * 0.5f, 500.0f);
+}
+
+void FillerTestSnapshotCleanup()
+{
+	l_TestTexture = nullptr;
+	s_snapshotGradient = nullptr;
+}

--- a/DEMO/FillerTest.cpp
+++ b/DEMO/FillerTest.cpp
@@ -1320,36 +1320,46 @@ static void drawPolyOtherBarry(float T_in, float DT)
 	Vertex V[4];
 	Face F;
 
-	float a = (T_in + DT) * 0.003f;
-	float c = cosf(a);
-	float s = sinf(a);
+	// seed==0 uses axis-aligned integer-valued vertices so vertex coords
+	// are bit-identical across platforms (no sinf/cosf, no libm noise).
+	// Any remaining native-vs-wasm diff in this configuration is purely a
+	// rasterizer-side bug. Non-zero seeds keep the original rotation path.
+	if (T_in == 0.0f) {
+		V[0].PX = 600.0f; V[0].PY = 200.0f;
+		V[1].PX = 1200.0f; V[1].PY = 200.0f;
+		V[2].PX = 1200.0f; V[2].PY = 800.0f;
+		V[3].PX = 600.0f; V[3].PY = 800.0f;
+		V[0].U = -1.0f / 512.0f; V[0].V = -1.0f / 512.0f;
+		V[1].U = 511.0f / 512.0f; V[1].V = -1.0f / 512.0f;
+		V[2].U = 511.0f / 512.0f; V[2].V = 511.0f / 512.0f;
+		V[3].U = -1.0f / 512.0f;  V[3].V = 511.0f / 512.0f;
+		for (int i = 0; i < 4; ++i) V[i].TPos.z = 1.0f;
+	} else {
+		float a = (T_in + DT) * 0.003f;
+		float c = cosf(a);
+		float s = sinf(a);
 
-	const auto W = 280;
-	const auto H = 250;
+		const auto W = 280;
+		const auto H = 250;
 
-	V[0].PX = 900.1f - W * c - H * s;
-	V[0].PY = 400.1f + W * s - H * c;
-	V[0].TPos.z = 1.0f;
-	V[0].U = -1.0f / 512.0f;
-	V[0].V = -1.0f / 512.0f;
+		V[0].PX = 900.1f - W * c - H * s;
+		V[0].PY = 400.1f + W * s - H * c;
+		V[0].U = -1.0f / 512.0f; V[0].V = -1.0f / 512.0f;
 
-	V[1].PX = 900.1f + W * c - H * s;
-	V[1].PY = 400.1f - W * s - H * c;
-	V[1].TPos.z = 1.0f;
-	V[1].U = 511.0f / 512.0f;
-	V[1].V = -1.0f / 512.0f;
+		V[1].PX = 900.1f + W * c - H * s;
+		V[1].PY = 400.1f - W * s - H * c;
+		V[1].U = 511.0f / 512.0f; V[1].V = -1.0f / 512.0f;
 
-	V[2].PX = 900.1f + W * c + H * s;
-	V[2].PY = 400.1f - W * s + H * c;
-	V[2].TPos.z = 1.0f;
-	V[2].U = 511.0f / 512.0f;
-	V[2].V = 511.0f / 512.0f;
+		V[2].PX = 900.1f + W * c + H * s;
+		V[2].PY = 400.1f - W * s + H * c;
+		V[2].U = 511.0f / 512.0f; V[2].V = 511.0f / 512.0f;
 
-	V[3].PX = 900.1f - W * c + H * s;
-	V[3].PY = 400.1f + W * s + H * c;
-	V[3].TPos.z = 1.0f;
-	V[3].U = -1.0f / 512.0f;
-	V[3].V = 511.0f / 512.0f;
+		V[3].PX = 900.1f - W * c + H * s;
+		V[3].PY = 400.1f + W * s + H * c;
+		V[3].U = -1.0f / 512.0f; V[3].V = 511.0f / 512.0f;
+
+		for (int i = 0; i < 4; ++i) V[i].TPos.z = 1.0f;
+	}
 
 	for (int i = 0; i < 4; i++) {
 		V[i].LR = V[i].LG = V[i].LB = V[i].LA = 255;

--- a/DEMO/FillerTest.h
+++ b/DEMO/FillerTest.h
@@ -4,6 +4,17 @@
 #include "Base/FDS_DECS.H"
 #include "FILLERS/F4Vec.h"
 
+#include <cstdint>
+
 void FillerTest();
+
+// Deterministic single-frame entry points for the snapshot harness. The
+// pair of triangles share the V0–V2 edge — diffing the rendered VPage
+// across native and wasm isolates rasterizer-edge / mask behaviour
+// without the rest of the city pipeline in the way. `seed` selects a
+// rotation; the same seed produces bit-identical input geometry.
+void FillerTestSnapshotInit(int xres, int yres);
+void FillerTestSnapshotRender(int32_t seed);
+void FillerTestSnapshotCleanup();
 
 #endif //_FILLERTEST_H_INCLUDED_

--- a/DEMO/GLAT.H
+++ b/DEMO/GLAT.H
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+// Per-tick state captured by the Glat snapshot harness. CamX/Y/Z and Rx/Ry/Rz
+// are read from GlatoScene at the end of tick(); ST is the dominant
+// animation parameter (a piecewise function of Timer that drives almost
+// every visual in Glat) and is captured at the moment it's computed.
+struct GlatoTraceSample {
+    int32_t timer;
+    float st;
+    float rx;
+    float ry;
+    float rz;
+    float camX;
+    float camY;
+    float camZ;
+};
+
+// If non-null, GlatoScene::tick() invokes this once per tick with the
+// current state. Snapshot mode wires it up to record a CSV trace; the
+// production demo path leaves it null.
+using GlatoTraceHook = void (*)(const GlatoTraceSample&);
+extern GlatoTraceHook g_glatoTraceHook;

--- a/DEMO/Glat.cpp
+++ b/DEMO/Glat.cpp
@@ -228,6 +228,11 @@ struct GlatoScene : SceneDriver {
 	XMMMatrix CamMat;
 	float Rx = 0.0f, Ry = 0.0f, Rz = 0.0f;
 
+	// Conditionally written inside tick (only while ST is in range); reads
+	// outside that window must see the last computed value, not 0.
+	float Code_RS = 0.0f;
+	float Gfx_RS = 0.0f;
+
 	dword TTrd = 0;
 	int32_t timerStack[20] = {};
 	int32_t timerIndex = 0;
@@ -259,9 +264,9 @@ struct GlatoScene : SceneDriver {
 		float a = 0.0f, bb = 0.0f, c = 0.0f, d = 0.0f;
 		float X1 = 0.0f, X2 = 0.0f;
 		float u, v, u1, v1, u2, v2, r, g, b;
-		float Code_R1 = 0.0f, Code_RS = 0.0f, Code_R2;
+		float Code_R1 = 0.0f, Code_R2;
 		float CCosR1, CSinR1, CCosR2, CSinR2;
-		float Gfx_R1, Gfx_R2, GCosR1, GSinR1, GCosR2, GSinR2, Gfx_RS = 0.0f;
+		float Gfx_R1, Gfx_R2, GCosR1, GSinR1, GCosR2, GSinR2;
 		XMMVector Intersection1, Origin1, Direction1, U;
 		int X, Y;
 		float Radius = 1;

--- a/DEMO/Glat.cpp
+++ b/DEMO/Glat.cpp
@@ -1,4 +1,5 @@
 #include "Rev.h"
+#include "GLAT.H"
 #include "IMGGENR/IMGGENR.H"
 #include "SceneTick.h"
 #include "Scenes.h"
@@ -56,6 +57,8 @@ static Texture *SfxTexture;
 static Image *SfxImage;
 
 static int32_t InitScreenXRes, InitScreenYRes;
+
+GlatoTraceHook g_glatoTraceHook = nullptr;
 
 
 void Initialize_Glato()
@@ -649,6 +652,18 @@ struct GlatoScene : SceneDriver {
 //		Flip(VSurface);
 		if (Keyboard[ScESC])
 			Timer = 1000000;
+
+		if (g_glatoTraceHook) {
+			GlatoTraceSample s = {
+				.timer = Timer,
+				.st = ST,
+				.rx = Rx, .ry = Ry, .rz = Rz,
+				.camX = CameraPos.x,
+				.camY = CameraPos.y,
+				.camZ = CameraPos.z,
+			};
+			g_glatoTraceHook(s);
+		}
 		return true;
 	}
 

--- a/DEMO/REV.CPP
+++ b/DEMO/REV.CPP
@@ -1122,8 +1122,16 @@ int main(int argc, const char *argv[])
 	SnapshotConfig snap;
 	if (ParseSnapshotArgs(argc, argv, snap)) {
 		// Headless deterministic dump path — no SDL window, no music.
-		// Used to diff native vs wasm at the pixel level.
-		return RunCitySnapshot(snap, g_demoXRes, g_demoYRes);
+		// Used to diff native vs wasm at the pixel level / per-tick state.
+		if (snap.scene == "city") {
+			return RunCitySnapshot(snap, g_demoXRes, g_demoYRes);
+		}
+		if (snap.scene == "glat-trace") {
+			return RunGlatTrace(snap, g_demoXRes, g_demoYRes);
+		}
+		fprintf(stderr, "[SNAPSHOT] unknown scene '%s' (try city, glat-trace)\n",
+		        snap.scene.c_str());
+		return 2;
 	}
 
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);

--- a/DEMO/REV.CPP
+++ b/DEMO/REV.CPP
@@ -1129,7 +1129,10 @@ int main(int argc, const char *argv[])
 		if (snap.scene == "glat-trace") {
 			return RunGlatTrace(snap, g_demoXRes, g_demoYRes);
 		}
-		fprintf(stderr, "[SNAPSHOT] unknown scene '%s' (try city, glat-trace)\n",
+		if (snap.scene == "filler") {
+			return RunFillerTestSnapshot(snap, g_demoXRes, g_demoYRes);
+		}
+		fprintf(stderr, "[SNAPSHOT] unknown scene '%s' (try city, glat-trace, filler)\n",
 		        snap.scene.c_str());
 		return 2;
 	}

--- a/DEMO/REV.CPP
+++ b/DEMO/REV.CPP
@@ -1201,11 +1201,54 @@ int main(int argc, const char *argv[])
 		if (event.type == SDL_QUIT) {
 			break;
 		}
-		if (event.type == SDL_KEYDOWN) {
-			Keyboard[event.key.keysym.scancode] = 1;
-		}
-		if (event.type == SDL_KEYUP) {
-			Keyboard[event.key.keysym.scancode] = 0;
+		if (event.type == SDL_KEYDOWN || event.type == SDL_KEYUP) {
+			// FDS_DEFS.H ScXxx constants are PS/2 set-1 scancodes inherited
+			// from the original DOS build; SDL2 reports USB-HID scancodes,
+			// which collide for almost everything. Only ScESC happens to
+			// match (both = 41), which is why exit worked but pause/tab/etc.
+			// did not. Translate so the legacy scene code keeps working.
+			int legacy = -1;
+			switch (event.key.keysym.scancode) {
+				case SDL_SCANCODE_ESCAPE:    legacy = ScESC; break;
+				case SDL_SCANCODE_F1:        legacy = ScF1; break;
+				case SDL_SCANCODE_F2:        legacy = ScF2; break;
+				case SDL_SCANCODE_F11:       legacy = ScF11; break;
+				case SDL_SCANCODE_TAB:       legacy = ScTab; break;
+				case SDL_SCANCODE_SPACE:     legacy = ScSpace; break;
+				case SDL_SCANCODE_LCTRL:
+				case SDL_SCANCODE_RCTRL:     legacy = ScCtrl; break;
+				case SDL_SCANCODE_LEFT:      legacy = ScLeft; break;
+				case SDL_SCANCODE_RIGHT:     legacy = ScRight; break;
+				case SDL_SCANCODE_UP:        legacy = ScUp; break;
+				case SDL_SCANCODE_DOWN:      legacy = ScDown; break;
+				case SDL_SCANCODE_HOME:      legacy = ScHome; break;
+				case SDL_SCANCODE_END:       legacy = ScEnd; break;
+				case SDL_SCANCODE_PAGEUP:    legacy = ScPgUp; break;
+				case SDL_SCANCODE_PAGEDOWN:  legacy = ScPgDn; break;
+				case SDL_SCANCODE_KP_MINUS:
+				case SDL_SCANCODE_MINUS:     legacy = ScGrayMinus; break;
+				case SDL_SCANCODE_KP_PLUS:
+				case SDL_SCANCODE_EQUALS:    legacy = ScGrayPlus; break;
+				case SDL_SCANCODE_LEFTBRACKET:  legacy = ScOpenSq; break;
+				case SDL_SCANCODE_RIGHTBRACKET: legacy = ScCloseSq; break;
+				case SDL_SCANCODE_COMMA:     legacy = ScComma; break;
+				case SDL_SCANCODE_PERIOD:    legacy = ScPeriod; break;
+				case SDL_SCANCODE_A:         legacy = ScA; break;
+				case SDL_SCANCODE_C:         legacy = ScC; break;
+				case SDL_SCANCODE_D:         legacy = ScD; break;
+				case SDL_SCANCODE_E:         legacy = ScE; break;
+				case SDL_SCANCODE_H:         legacy = ScH; break;
+				case SDL_SCANCODE_M:         legacy = ScM; break;
+				case SDL_SCANCODE_P:         legacy = ScP; break;
+				case SDL_SCANCODE_R:         legacy = ScR; break;
+				case SDL_SCANCODE_U:         legacy = ScU; break;
+				case SDL_SCANCODE_Y:         legacy = ScY; break;
+				case SDL_SCANCODE_Z:         legacy = ScZ; break;
+				default: break;
+			}
+			if (legacy >= 0) {
+				Keyboard[legacy] = (event.type == SDL_KEYDOWN) ? 1 : 0;
+			}
 		}
     }
 

--- a/DEMO/REV.CPP
+++ b/DEMO/REV.CPP
@@ -461,6 +461,7 @@ material global ID or ptr
 #include "FillerTest.h"
 #include "ImageCompression.h"
 #include "PhotonTracer.h"
+#include "Snapshot.h"
 #include <float.h>
 #include <Base/TriMesh.h>
 #include "Config.h"
@@ -1117,6 +1118,13 @@ int main(int argc, const char *argv[])
 	g_demoXRes = cfg.extractInteger("ResolutionX");
 	g_demoYRes = cfg.extractInteger("ResolutionY");
 	g_fullScreenMode = cfg.extractInteger("FullScreenMode");
+
+	SnapshotConfig snap;
+	if (ParseSnapshotArgs(argc, argv, snap)) {
+		// Headless deterministic dump path — no SDL window, no music.
+		// Used to diff native vs wasm at the pixel level.
+		return RunCitySnapshot(snap, g_demoXRes, g_demoYRes);
+	}
 
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
 

--- a/DEMO/Snapshot.cpp
+++ b/DEMO/Snapshot.cpp
@@ -1,6 +1,7 @@
 #include "Snapshot.h"
 
 #include "CITY.H"
+#include "GLAT.H"
 #include "Rev.h"
 #include "Scenes.h"
 #include "SceneTick.h"
@@ -92,6 +93,56 @@ void write_pgm16(const char* path, const word* z, int xres, int yres) {
 
 void noop_flip(VESA_Surface*) {}
 
+// Bootstrap the FDS/VESA pipeline + ThreadPool without touching SDL or
+// Modplayer. Both city and glat snapshot modes share this. Returns false
+// on failure.
+bool initSnapshotEnvironment(int xres, int yres) {
+    if (!FDS_Init(static_cast<unsigned short>(xres),
+                  static_cast<unsigned short>(yres), 32)) {
+        std::fprintf(stderr, "[SNAPSHOT] FDS_Init failed\n");
+        return false;
+    }
+
+    static VESA_Surface surf = {};
+    surf.X = xres;
+    surf.Y = yres;
+    surf.BPP = 32;
+    surf.CPP = 4;
+    surf.BPSL = surf.CPP * surf.X;
+    surf.PageSize = surf.BPSL * surf.Y;
+    const std::size_t zSize = sizeof(word) * static_cast<std::size_t>(xres) * yres;
+    surf.Data = static_cast<byte*>(std::malloc(surf.PageSize + zSize));
+    if (!surf.Data) {
+        std::fprintf(stderr, "[SNAPSHOT] malloc framebuffer failed\n");
+        return false;
+    }
+    std::memset(surf.Data, 0, surf.PageSize + zSize);
+    surf.Flip = &noop_flip;
+
+    VESA_VPageExternal(&surf);
+    VESA_Surface2Global(MainSurf);
+
+    Generate_RGBFlares();
+    InitPolyStats(200);
+    ThreadPool::instance().init([]() {
+        InitPolyStats(200);
+        FPU_LPrecision();
+    });
+    FPU_LPrecision();
+
+    g_profilerActive = 0;
+    return true;
+}
+
+void ensureOutDir(const std::string& outDir) {
+    if (outDir.empty() || outDir == ".") return;
+#ifdef _WIN32
+    _mkdir(outDir.c_str());
+#else
+    mkdir(outDir.c_str(), 0755);
+#endif
+}
+
 } // namespace
 
 bool ParseSnapshotArgs(int argc, const char* argv[], SnapshotConfig& cfg) {
@@ -121,61 +172,8 @@ bool ParseSnapshotArgs(int argc, const char* argv[], SnapshotConfig& cfg) {
 }
 
 int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres) {
-    if (cfg.scene != "city") {
-        std::fprintf(stderr, "[SNAPSHOT] only --snapshot=city is implemented (got '%s')\n",
-                     cfg.scene.c_str());
-        return 2;
-    }
-
-    // mkdir -p outDir (best effort).
-    if (!cfg.outDir.empty() && cfg.outDir != ".") {
-#ifdef _WIN32
-        _mkdir(cfg.outDir.c_str());
-#else
-        mkdir(cfg.outDir.c_str(), 0755);
-#endif
-    }
-
-    if (!FDS_Init(static_cast<unsigned short>(xres),
-                  static_cast<unsigned short>(yres), 32)) {
-        std::fprintf(stderr, "[SNAPSHOT] FDS_Init failed\n");
-        return 3;
-    }
-
-    // Allocate a real framebuffer + Z-buffer surface so the rasterizer has
-    // somewhere to write. No window, no SDL — the Flip callback is a no-op.
-    VESA_Surface surf = {};
-    surf.X = xres;
-    surf.Y = yres;
-    surf.BPP = 32;
-    surf.CPP = 4;
-    surf.BPSL = surf.CPP * surf.X;
-    surf.PageSize = surf.BPSL * surf.Y;
-    const std::size_t zSize = sizeof(word) * static_cast<std::size_t>(xres) * yres;
-    surf.Data = static_cast<byte*>(std::malloc(surf.PageSize + zSize));
-    if (!surf.Data) {
-        std::fprintf(stderr, "[SNAPSHOT] malloc framebuffer failed\n");
-        return 4;
-    }
-    std::memset(surf.Data, 0, surf.PageSize + zSize);
-    surf.Flip = &noop_flip;
-
-    VESA_VPageExternal(&surf);
-    VESA_Surface2Global(MainSurf);
-
-    // Match the production init sequence used by CodeEntry, minus the audio
-    // / scene-sequence / SDL bits. ThreadPool is required because Render()
-    // dispatches tile work onto its workers.
-    Generate_RGBFlares();
-    InitPolyStats(200);
-    ThreadPool::instance().init([]() {
-        InitPolyStats(200);
-        FPU_LPrecision();
-    });
-    FPU_LPrecision();
-
-    // Suppress profiler overlay so it doesn't appear in the dumped frame.
-    g_profilerActive = 0;
+    ensureOutDir(cfg.outDir);
+    if (!initSnapshotEnvironment(xres, yres)) return 3;
 
     Initialize_City();
 
@@ -234,4 +232,65 @@ int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres) {
 
     ThreadPool::instance().close();
     return produced > 0 ? 0 : 5;
+}
+
+namespace {
+// Records every GlatoScene::tick() invocation; flushed to CSV at the end.
+std::vector<GlatoTraceSample> g_glatoTraceBuf;
+void glatoTraceCollector(const GlatoTraceSample& s) {
+    g_glatoTraceBuf.push_back(s);
+}
+} // namespace
+
+int RunGlatTrace(const SnapshotConfig& cfg, int xres, int yres) {
+    ensureOutDir(cfg.outDir);
+    if (!initSnapshotEnvironment(xres, yres)) return 3;
+
+    Initialize_Glato();
+
+    // Default sweep: every 10 ticks across Glat's playable range (Timer
+    // < 3500). Override with --snapshot=glat-trace@t=N1,N2,...
+    std::vector<int32_t> timestamps = cfg.timestamps;
+    if (timestamps.empty()) {
+        for (int32_t t = 0; t < 3500; t += 10) timestamps.push_back(t);
+    }
+
+    g_glatoTraceBuf.clear();
+    g_glatoTraceBuf.reserve(timestamps.size());
+    g_glatoTraceHook = &glatoTraceCollector;
+
+    auto driver = createGlatoScene();
+    driver->init();
+
+    for (int32_t ts : timestamps) {
+        std::srand(0);
+        Timer = ts;
+        std::memset((void*)Keyboard, 0, sizeof(Keyboard));
+        driver->tick();
+    }
+
+    driver->cleanup();
+    driver.reset();
+    g_glatoTraceHook = nullptr;
+
+    char csvPath[1024];
+    std::snprintf(csvPath, sizeof(csvPath), "%s/glat_trace.csv", cfg.outDir.c_str());
+    std::FILE* f = std::fopen(csvPath, "w");
+    if (!f) {
+        std::fprintf(stderr, "[SNAPSHOT] fopen('%s') failed: %s\n", csvPath, std::strerror(errno));
+        ThreadPool::instance().close();
+        return 4;
+    }
+    std::fprintf(f, "timer,st,rx,ry,rz,camX,camY,camZ\n");
+    // %.9g preserves enough digits to round-trip a float exactly so a
+    // single-bit divergence shows up as different text.
+    for (const auto& s : g_glatoTraceBuf) {
+        std::fprintf(f, "%d,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g\n",
+                     s.timer, s.st, s.rx, s.ry, s.rz, s.camX, s.camY, s.camZ);
+    }
+    std::fclose(f);
+    std::fprintf(stderr, "[SNAPSHOT] wrote %s (%zu rows)\n", csvPath, g_glatoTraceBuf.size());
+
+    ThreadPool::instance().close();
+    return 0;
 }

--- a/DEMO/Snapshot.cpp
+++ b/DEMO/Snapshot.cpp
@@ -1,0 +1,233 @@
+#include "Snapshot.h"
+
+#include "CITY.H"
+#include "Rev.h"
+#include "Scenes.h"
+#include "SceneTick.h"
+
+#include <Base/FDS_VARS.H>
+#include <Base/FDS_DECS.H>
+#include <Threads.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+#include <sys/stat.h>
+
+extern dword g_profilerActive;
+
+namespace {
+
+bool starts_with(std::string_view s, std::string_view prefix) {
+    return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+void parse_timestamps(std::string_view s, std::vector<int32_t>& out) {
+    // Accepts "N1,N2,N3"
+    std::size_t pos = 0;
+    while (pos <= s.size()) {
+        std::size_t end = s.find(',', pos);
+        if (end == std::string_view::npos) end = s.size();
+        if (end > pos) {
+            std::string token(s.substr(pos, end - pos));
+            char* endp = nullptr;
+            long v = std::strtol(token.c_str(), &endp, 10);
+            if (endp && *endp == '\0') {
+                out.push_back(static_cast<int32_t>(v));
+            } else {
+                std::fprintf(stderr, "[SNAPSHOT] ignoring non-integer timestamp '%s'\n",
+                             token.c_str());
+            }
+        }
+        pos = end + 1;
+    }
+}
+
+void write_ppm(const char* path, const byte* bgra, int xres, int yres, int bpsl) {
+    std::FILE* f = std::fopen(path, "wb");
+    if (!f) {
+        std::fprintf(stderr, "[SNAPSHOT] fopen('%s') failed: %s\n", path, std::strerror(errno));
+        return;
+    }
+    std::fprintf(f, "P6\n%d %d\n255\n", xres, yres);
+    std::vector<unsigned char> row(xres * 3);
+    for (int y = 0; y < yres; ++y) {
+        const dword* src = reinterpret_cast<const dword*>(bgra + y * bpsl);
+        for (int x = 0; x < xres; ++x) {
+            // VPage is ARGB8888 dwords; PPM wants RGB.
+            dword px = src[x];
+            row[x * 3 + 0] = (px >> 16) & 0xFF; // R
+            row[x * 3 + 1] = (px >>  8) & 0xFF; // G
+            row[x * 3 + 2] = (px      ) & 0xFF; // B
+        }
+        std::fwrite(row.data(), 1, row.size(), f);
+    }
+    std::fclose(f);
+    std::fprintf(stderr, "[SNAPSHOT] wrote %s\n", path);
+}
+
+void write_pgm16(const char* path, const word* z, int xres, int yres) {
+    std::FILE* f = std::fopen(path, "wb");
+    if (!f) {
+        std::fprintf(stderr, "[SNAPSHOT] fopen('%s') failed: %s\n", path, std::strerror(errno));
+        return;
+    }
+    std::fprintf(f, "P5\n%d %d\n65535\n", xres, yres);
+    std::vector<unsigned char> row(xres * 2);
+    for (int y = 0; y < yres; ++y) {
+        for (int x = 0; x < xres; ++x) {
+            // PGM 16-bit is big-endian.
+            word v = z[y * xres + x];
+            row[x * 2 + 0] = (v >> 8) & 0xFF;
+            row[x * 2 + 1] = v & 0xFF;
+        }
+        std::fwrite(row.data(), 1, row.size(), f);
+    }
+    std::fclose(f);
+    std::fprintf(stderr, "[SNAPSHOT] wrote %s\n", path);
+}
+
+void noop_flip(VESA_Surface*) {}
+
+} // namespace
+
+bool ParseSnapshotArgs(int argc, const char* argv[], SnapshotConfig& cfg) {
+    bool found = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a(argv[i]);
+        if (starts_with(a, "--snapshot=")) {
+            std::string_view rest = a.substr(strlen("--snapshot="));
+            std::size_t at = rest.find('@');
+            if (at == std::string_view::npos) {
+                cfg.scene = std::string(rest);
+            } else {
+                cfg.scene = std::string(rest.substr(0, at));
+                std::string_view tail = rest.substr(at + 1);
+                if (starts_with(tail, "t=")) {
+                    parse_timestamps(tail.substr(2), cfg.timestamps);
+                }
+            }
+            found = true;
+        } else if (starts_with(a, "--out=")) {
+            cfg.outDir = std::string(a.substr(strlen("--out=")));
+        }
+    }
+    // If no timestamps were passed, RunCitySnapshot picks an even sweep
+    // across the scene's playable range once it knows CTPartTime.
+    return found;
+}
+
+int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres) {
+    if (cfg.scene != "city") {
+        std::fprintf(stderr, "[SNAPSHOT] only --snapshot=city is implemented (got '%s')\n",
+                     cfg.scene.c_str());
+        return 2;
+    }
+
+    // mkdir -p outDir (best effort).
+    if (!cfg.outDir.empty() && cfg.outDir != ".") {
+#ifdef _WIN32
+        _mkdir(cfg.outDir.c_str());
+#else
+        mkdir(cfg.outDir.c_str(), 0755);
+#endif
+    }
+
+    if (!FDS_Init(static_cast<unsigned short>(xres),
+                  static_cast<unsigned short>(yres), 32)) {
+        std::fprintf(stderr, "[SNAPSHOT] FDS_Init failed\n");
+        return 3;
+    }
+
+    // Allocate a real framebuffer + Z-buffer surface so the rasterizer has
+    // somewhere to write. No window, no SDL — the Flip callback is a no-op.
+    VESA_Surface surf = {};
+    surf.X = xres;
+    surf.Y = yres;
+    surf.BPP = 32;
+    surf.CPP = 4;
+    surf.BPSL = surf.CPP * surf.X;
+    surf.PageSize = surf.BPSL * surf.Y;
+    const std::size_t zSize = sizeof(word) * static_cast<std::size_t>(xres) * yres;
+    surf.Data = static_cast<byte*>(std::malloc(surf.PageSize + zSize));
+    if (!surf.Data) {
+        std::fprintf(stderr, "[SNAPSHOT] malloc framebuffer failed\n");
+        return 4;
+    }
+    std::memset(surf.Data, 0, surf.PageSize + zSize);
+    surf.Flip = &noop_flip;
+
+    VESA_VPageExternal(&surf);
+    VESA_Surface2Global(MainSurf);
+
+    // Match the production init sequence used by CodeEntry, minus the audio
+    // / scene-sequence / SDL bits. ThreadPool is required because Render()
+    // dispatches tile work onto its workers.
+    Generate_RGBFlares();
+    InitPolyStats(200);
+    ThreadPool::instance().init([]() {
+        InitPolyStats(200);
+        FPU_LPrecision();
+    });
+    FPU_LPrecision();
+
+    // Suppress profiler overlay so it doesn't appear in the dumped frame.
+    g_profilerActive = 0;
+
+    Initialize_City();
+
+    const int32_t ctPart = getCityCTPartTime();
+    std::fprintf(stderr, "[SNAPSHOT] City CTPartTime = %d (Timer must be < this for tick to render)\n",
+                 ctPart);
+
+    std::vector<int32_t> timestamps = cfg.timestamps;
+    if (timestamps.empty() && ctPart > 0) {
+        // Even sweep across the scene's playable range.
+        for (int i = 1; i <= 9; i += 2) {
+            timestamps.push_back(ctPart * i / 10);
+        }
+    }
+
+    auto driver = createCityScene();
+    driver->init();
+
+    int produced = 0;
+    for (int32_t ts : timestamps) {
+        if (ctPart > 0 && ts >= ctPart) {
+            std::fprintf(stderr,
+                         "[SNAPSHOT] timestamp %d >= CTPartTime %d; clamping to %d\n",
+                         ts, ctPart, ctPart - 1);
+            ts = ctPart - 1;
+        }
+        // TTrd = Timer makes dTime = 0 in tick(); avoids any branch tied to
+        // wall-clock motion.
+        Timer = ts;
+        // Best-effort: clear any stale Keyboard state between frames.
+        std::memset((void*)Keyboard, 0, sizeof(Keyboard));
+
+        bool more = driver->tick();
+        (void)more;
+
+        char colorPath[1024];
+        char zPath[1024];
+        std::snprintf(colorPath, sizeof(colorPath), "%s/city_t%06d_color.ppm",
+                      cfg.outDir.c_str(), ts);
+        std::snprintf(zPath, sizeof(zPath), "%s/city_t%06d_z.pgm",
+                      cfg.outDir.c_str(), ts);
+
+        write_ppm(colorPath, MainSurf->Data, xres, yres, MainSurf->BPSL);
+        write_pgm16(zPath,
+                    reinterpret_cast<const word*>(MainSurf->Data + MainSurf->PageSize),
+                    xres, yres);
+        ++produced;
+    }
+
+    driver->cleanup();
+    driver.reset();
+
+    ThreadPool::instance().close();
+    return produced > 0 ? 0 : 5;
+}

--- a/DEMO/Snapshot.cpp
+++ b/DEMO/Snapshot.cpp
@@ -202,6 +202,10 @@ int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres) {
                          ts, ctPart, ctPart - 1);
             ts = ctPart - 1;
         }
+        // Reset rand() to a fixed seed each frame. Omni-light flicker and
+        // similar effects use rand(); without this the snapshot is
+        // non-deterministic across invocations even on the same build.
+        std::srand(0);
         // TTrd = Timer makes dTime = 0 in tick(); avoids any branch tied to
         // wall-clock motion.
         Timer = ts;

--- a/DEMO/Snapshot.cpp
+++ b/DEMO/Snapshot.cpp
@@ -1,6 +1,7 @@
 #include "Snapshot.h"
 
 #include "CITY.H"
+#include "FillerTest.h"
 #include "GLAT.H"
 #include "Rev.h"
 #include "Scenes.h"
@@ -293,4 +294,36 @@ int RunGlatTrace(const SnapshotConfig& cfg, int xres, int yres) {
 
     ThreadPool::instance().close();
     return 0;
+}
+
+int RunFillerTestSnapshot(const SnapshotConfig& cfg, int xres, int yres) {
+    ensureOutDir(cfg.outDir);
+    if (!initSnapshotEnvironment(xres, yres)) return 3;
+
+    FillerTestSnapshotInit(xres, yres);
+
+    std::vector<int32_t> seeds = cfg.timestamps;
+    if (seeds.empty()) seeds = {0};
+
+    int produced = 0;
+    for (int32_t seed : seeds) {
+        FillerTestSnapshotRender(seed);
+
+        char colorPath[1024];
+        char zPath[1024];
+        std::snprintf(colorPath, sizeof(colorPath), "%s/filler_t%06d_color.ppm",
+                      cfg.outDir.c_str(), seed);
+        std::snprintf(zPath, sizeof(zPath), "%s/filler_t%06d_z.pgm",
+                      cfg.outDir.c_str(), seed);
+
+        write_ppm(colorPath, MainSurf->Data, xres, yres, MainSurf->BPSL);
+        write_pgm16(zPath,
+                    reinterpret_cast<const word*>(MainSurf->Data + MainSurf->PageSize),
+                    xres, yres);
+        ++produced;
+    }
+
+    FillerTestSnapshotCleanup();
+    ThreadPool::instance().close();
+    return produced > 0 ? 0 : 5;
 }

--- a/DEMO/Snapshot.h
+++ b/DEMO/Snapshot.h
@@ -28,3 +28,9 @@ int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres);
 // state to <outDir>/glat_trace.csv. Useful for cross-platform / cross-
 // commit comparison of animation behaviour.
 int RunGlatTrace(const SnapshotConfig& cfg, int xres, int yres);
+
+// Renders FillerTest's two-triangle quad through TheOtherBarry per seed,
+// dumping VPage/Z to <outDir>/filler_t<seed>_color.ppm + _z.pgm. Used to
+// reproduce rasterizer-edge / mask divergence between native and wasm in
+// isolation from the city pipeline.
+int RunFillerTestSnapshot(const SnapshotConfig& cfg, int xres, int yres);

--- a/DEMO/Snapshot.h
+++ b/DEMO/Snapshot.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// CLI-driven scene snapshot harness. Renders one or more deterministic
+// frames of a scene without the SDL window or audio path so we can diff
+// native vs wasm output at the pixel level.
+//
+// Invocation (parsed by ParseSnapshotArgs):
+//   DEMO --snapshot=city@t=1000,5000,10000 [--out=PATH]
+//
+// For each requested Timer value we drive one tick() of the City scene
+// driver and dump VPage as PPM (color) and the Z-buffer as PGM.
+
+struct SnapshotConfig {
+    std::string scene;
+    std::vector<int32_t> timestamps;
+    std::string outDir = ".";
+};
+
+bool ParseSnapshotArgs(int argc, const char* argv[], SnapshotConfig& cfg);
+
+int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres);

--- a/DEMO/Snapshot.h
+++ b/DEMO/Snapshot.h
@@ -23,3 +23,8 @@ struct SnapshotConfig {
 bool ParseSnapshotArgs(int argc, const char* argv[], SnapshotConfig& cfg);
 
 int RunCitySnapshot(const SnapshotConfig& cfg, int xres, int yres);
+
+// Drives Glat through a deterministic Timer sweep and records per-tick
+// state to <outDir>/glat_trace.csv. Useful for cross-platform / cross-
+// commit comparison of animation behaviour.
+int RunGlatTrace(const SnapshotConfig& cfg, int xres, int yres);

--- a/DEMO/shell.html
+++ b/DEMO/shell.html
@@ -47,6 +47,16 @@
         setStatus('Exception thrown, see console');
         setStatus = function(t) { if (t) console.error('[post-exception] ' + t); };
       };
+      // The browser captures Tab (focus nav), function keys, arrows, etc.
+      // before they reach SDL. Block default for keys the demo cares about.
+      var swallowed = new Set([
+        'Tab', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
+        'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+        'Home', 'End', 'PageUp', 'PageDown', ' ', 'Space'
+      ]);
+      window.addEventListener('keydown', function(e) {
+        if (swallowed.has(e.key)) e.preventDefault();
+      }, { capture: true });
     </script>
     {{{ SCRIPT }}}
   </body>

--- a/FDS/Base/FDS_VARS.H
+++ b/FDS/Base/FDS_VARS.H
@@ -838,8 +838,22 @@ inline void FastWrite(void *p, dword data, dword n)
 
 inline void rcpss(float *s)
 {
+#if defined(__EMSCRIPTEN__)
+	// simde maps _mm_rcp_ss to wasm_f32x4_div (full IEEE precision) on wasm,
+	// while x86/arm64 give ~12-bit approximate. The rasterizer was tuned for
+	// approximate-reciprocal bias and produces per-span seam artifacts when
+	// the reciprocal is too accurate. Use a bit-trick + 1 Newton step to
+	// match x86 RCPSS precision on wasm.
+	float a = *s;
+	int32_t i;
+	__builtin_memcpy(&i, &a, sizeof(i));
+	i = 0x7EF311C3 - i;
+	float y;
+	__builtin_memcpy(&y, &i, sizeof(y));
+	*s = y * (2.0f - a * y);
+#else
 	*s = _mm_cvtss_f32(_mm_rcp_ss(_mm_load_ss(s)));
-	//*s = 1.0 / *s;
+#endif
 }
 
 #pragma pack (pop)

--- a/FDS/FILLERS/Mekalele.h
+++ b/FDS/FILLERS/Mekalele.h
@@ -196,9 +196,9 @@ struct TileRasterizer {
 		for (int32_t y = 0; y != TILE_SIZE; ++y, a0 += tile.dady, b0 += tile.dbdy, c0 += tile.dcdy, span += ctx.xres) {
 			auto p_mask = (p_a | p_b | p_c) >= 0;
 			if (horizontal_or(p_mask)) {
-				Vec8f p_z = approx_recipr(p_rz);
+				Vec8f p_z = barry::compat_approx_recipr(p_rz);
 
-				auto z_candidate = (Vec8ui(0xFF80) - static_cast<Vec8ui>(roundi(g_zscale * p_z)));
+				auto z_candidate = (Vec8ui(0xFF80) - static_cast<Vec8ui>(barry::compat_roundi(g_zscale * p_z)));
 				Vec8us z_existing_c;
 				z_existing_c.load_a(span.zbuffer);
 				auto z_existing = extend(z_existing_c);
@@ -209,8 +209,8 @@ struct TileRasterizer {
 
 				if (horizontal_or(p_mask)) {
 					*(__m128i*)span.zbuffer = _mm_blendv_epi8(*(__m128i*)span.zbuffer, compress(z_candidate), compress(Vec8ui(p_mask)));
-					Vec8i u = roundi(p_uz * p_z * UScaleFactor);
-					Vec8i v = roundi(p_vz * p_z * VScaleFactor);
+					Vec8i u = barry::compat_roundi(p_uz * p_z * UScaleFactor);
+					Vec8i v = barry::compat_roundi(p_vz * p_z * VScaleFactor);
 
 					Vec8i tu = packed_tile_u(u, LogHeight, t_umask_swizzled);
 					Vec8i tv = packed_tile_v(v, t_vmask);

--- a/FDS/FILLERS/Mekalele.h
+++ b/FDS/FILLERS/Mekalele.h
@@ -195,7 +195,7 @@ struct TileRasterizer {
 
 		for (int32_t y = 0; y != TILE_SIZE; ++y, a0 += tile.dady, b0 += tile.dbdy, c0 += tile.dcdy, span += ctx.xres) {
 			auto p_mask = (p_a | p_b | p_c) >= 0;
-			if (horizontal_or(p_mask)) {
+			if (_mm256_movemask_epi8(*(__m256i*)(&p_mask)) != 0) {
 				Vec8f p_z = barry::compat_approx_recipr(p_rz);
 
 				auto z_candidate = (Vec8ui(0xFF80) - static_cast<Vec8ui>(barry::compat_roundi(g_zscale * p_z)));
@@ -207,7 +207,7 @@ struct TileRasterizer {
 
 				p_mask &= zmask;
 
-				if (horizontal_or(p_mask)) {
+				if (_mm256_movemask_epi8(*(__m256i*)(&p_mask)) != 0) {
 					*(__m128i*)span.zbuffer = _mm_blendv_epi8(*(__m128i*)span.zbuffer, compress(z_candidate), compress(Vec8ui(p_mask)));
 					Vec8i u = barry::compat_roundi(p_uz * p_z * UScaleFactor);
 					Vec8i v = barry::compat_roundi(p_vz * p_z * VScaleFactor);

--- a/FDS/FILLERS/TheOtherBarry.h
+++ b/FDS/FILLERS/TheOtherBarry.h
@@ -82,28 +82,39 @@ inline TScreenCoord orient2d(
 	return (int64_t(bx - ax) * int64_t(cy - ay) - int64_t(by - ay) * int64_t(cx - ax)) >> SUBPIXEL_BITS;
 }
 
-// Native (x86 RCPPS, arm64 vrecpeq_f32) and wasm (simde → exact 1/x) all
-// produce *different* bit patterns even at similar nominal precision.
-// The rasterizer's per-tile UV chain is sensitive enough that those
-// differences flip Z-test outcomes at polygon edges and shift point-
-// sampled texel lookups by 1 — visible as polygon seams native-side and
-// black speckle / heavier divergence wasm-side. Use a deterministic
-// bit-trick + 1 Newton-Raphson step on every target so all builds compute
-// the same ~12-bit approximate reciprocal.
+// On wasm, simde maps _mm_rcp_ps / _mm256_rcp_ps to wasm_f32x4_div(1, x) —
+// full IEEE precision. The rasterizer's perspective-correct mapping was
+// tuned for the ~12-bit approximate reciprocal that x86 (RCPPS) and arm64
+// (vrecpeq_f32) produce; the extra precision lands UVs exactly on texel
+// boundaries where the float-to-int convert flips. Bit-trick + 1 Newton
+// step gives matching ~12-bit precision on wasm. Native paths keep their
+// hardware reciprocal — switching arm64 to the bit-trick path shifted
+// pass-1/pass-2 Z values relative to each other and let the wobble bleed
+// through opaque geometry in the City scene.
 inline Vec8f compat_approx_recipr(Vec8f a) {
+#if defined(__EMSCRIPTEN__)
 	Vec8i ai = _mm256_castps_si256(a);
 	Vec8i mi = Vec8i(0x7EF311C3) - ai;
 	Vec8f y = _mm256_castsi256_ps(mi);
 	return y * (Vec8f(2.0f) - a * y);
+#else
+	return approx_recipr(a);
+#endif
 }
 
-// The rasterizer's texel addressing was tuned for ROUND_UP at the float→int
-// step. Native (x86 MXCSR / arm64 FPCR) gets that via FPU_LPrecision(); wasm
-// has no rounding-mode register, so we have to emulate. Use explicit ceil
-// before the convert on every target so the rasterizer behaves identically
-// regardless of FPCR — no implicit dependency on the host rounding mode.
+// On wasm, _mm256_cvtps_epi32 → simde → nearbyintf which uses the C-library
+// rounding mode (round-to-nearest-even on wasm, with no way to change it).
+// On x86/arm64 the same call respects the ROUND_UP mode that FPU_LPrecision()
+// sets, biasing every FP op feeding into the convert; the rasterizer's
+// per-pixel UV stepping accumulates that bias. Emulate via explicit ceil
+// before convert on wasm; native keeps the FPCR-driven path so the City
+// scene's pass-2 Z-test still overdraws the wobbled reflection correctly.
 inline Vec8i compat_roundi(Vec8f a) {
+#if defined(__EMSCRIPTEN__)
 	return _mm256_cvtps_epi32(_mm256_ceil_ps(a));
+#else
+	return roundi(a);
+#endif
 }
 
 // block-tiling adjustment functions

--- a/FDS/FILLERS/TheOtherBarry.h
+++ b/FDS/FILLERS/TheOtherBarry.h
@@ -245,7 +245,15 @@ struct TileRasterizer {
 		//Vec16s rg
 		for (int32_t y = 0; y != TILE_SIZE; ++y, a0 += tile.dady, b0 += tile.dbdy, c0 += tile.dcdy, span += bpsl_u32, zspan += XRes) {
 			auto p_mask = (p_a | p_b | p_c) >= 0;
-			if (horizontal_or(p_mask)) {
+			// horizontal_or(Vec8ib) compiles to !_mm256_testz_si256(a,a).
+			// simde's wasm impl of testz misses some cases where only the
+			// low lane has bits set (we observed lane 0 = 0xFFFFFFFF +
+			// horizontal_or returning 0), which silently drops every pixel
+			// on a triangle edge whose 8-pixel SIMD row has only lane 0
+			// inside the triangle. _mm256_movemask_epi8 routes through a
+			// different simde primitive that handles this correctly on
+			// every target.
+			if (_mm256_movemask_epi8(*(__m256i*)(&p_mask)) != 0) {
 				Vec8f p_z = compat_approx_recipr(p_rz);
 
 				auto z_candidate = (Vec8ui(0xFF80) - static_cast<Vec8ui>(compat_roundi(g_zscale * p_z)));
@@ -257,7 +265,7 @@ struct TileRasterizer {
 
 				p_mask &= zmask;
 
-				if (horizontal_or(p_mask)) {
+				if (_mm256_movemask_epi8(*(__m256i*)(&p_mask)) != 0) {
 
 //					if constexpr (BlendMode != TBlendMode::TRANSPARENT) {
 						*(__m128i*)zspan = _mm_blendv_epi8(*(__m128i*)zspan, compress(z_candidate), compress(Vec8ui(p_mask)));

--- a/FDS/FILLERS/TheOtherBarry.h
+++ b/FDS/FILLERS/TheOtherBarry.h
@@ -81,6 +81,41 @@ inline TScreenCoord orient2d(
 	return (int64_t(bx - ax) * int64_t(cy - ay) - int64_t(by - ay) * int64_t(cx - ax)) >> SUBPIXEL_BITS;
 }
 
+// On wasm, simde maps _mm_rcp_ps / _mm256_rcp_ps to wasm_f32x4_div(1, x) —
+// full IEEE precision. The rasterizer's perspective-correct mapping was
+// tuned for the ~12-bit approximate reciprocal that x86 (RCPPS) and arm64
+// (vrecpeq_f32) produce; the extra precision lands UVs exactly on texel
+// boundaries where the float-to-int convert flips, producing 1-pixel
+// perspective seam artifacts. Bit-trick initial estimate + 1 Newton-Raphson
+// step gives matching ~12-bit precision on wasm. Other targets keep the
+// native path.
+inline Vec8f compat_approx_recipr(Vec8f a) {
+#if defined(__EMSCRIPTEN__)
+	Vec8i ai = _mm256_castps_si256(a);
+	Vec8i mi = Vec8i(0x7EF311C3) - ai;
+	Vec8f y = _mm256_castsi256_ps(mi);
+	return y * (Vec8f(2.0f) - a * y);
+#else
+	return approx_recipr(a);
+#endif
+}
+
+// On wasm, _mm256_cvtps_epi32 → simde → nearbyintf which uses the C-library
+// rounding mode (round-to-nearest-even on wasm, with no way to change it).
+// On x86/arm64 the same call respects the ROUND_UP mode that FPU_LPrecision()
+// sets, biasing UV/Z conversions slightly upward. Beyond the convert itself,
+// every preceding FP add/mul on x86/arm64 also rounds up by ~1 ULP, so by
+// the time a value reaches the convert it's accumulated a small upward bias.
+// Emulate that on wasm via ceil-after-tiny-relative-nudge so values that
+// would land exactly on integer boundaries pop to the same texel as macOS.
+inline Vec8i compat_roundi(Vec8f a) {
+#if defined(__EMSCRIPTEN__)
+	return _mm256_cvtps_epi32(_mm256_ceil_ps(a * Vec8f(1.0f + 1.0e-5f)));
+#else
+	return roundi(a);
+#endif
+}
+
 // block-tiling adjustment functions
 // Example for 256x256 texture
 //    3         2         1         0
@@ -221,9 +256,9 @@ struct TileRasterizer {
 		for (int32_t y = 0; y != TILE_SIZE; ++y, a0 += tile.dady, b0 += tile.dbdy, c0 += tile.dcdy, span += bpsl_u32, zspan += XRes) {
 			auto p_mask = (p_a | p_b | p_c) >= 0;
 			if (horizontal_or(p_mask)) {
-				Vec8f p_z = approx_recipr(p_rz);
+				Vec8f p_z = compat_approx_recipr(p_rz);
 
-				auto z_candidate = (Vec8ui(0xFF80) - static_cast<Vec8ui>(roundi(g_zscale * p_z)));
+				auto z_candidate = (Vec8ui(0xFF80) - static_cast<Vec8ui>(compat_roundi(g_zscale * p_z)));
 				Vec8us z_existing_c;
 				z_existing_c.load_a(zspan);
 				auto z_existing = extend(z_existing_c);
@@ -238,8 +273,8 @@ struct TileRasterizer {
 						*(__m128i*)zspan = _mm_blendv_epi8(*(__m128i*)zspan, compress(z_candidate), compress(Vec8ui(p_mask)));
 					//}
 
-					Vec8i u = roundi(p_uz * p_z * t0.UScaleFactor);
-					Vec8i v = roundi(p_vz * p_z * t0.VScaleFactor);
+					Vec8i u = compat_roundi(p_uz * p_z * t0.UScaleFactor);
+					Vec8i v = compat_roundi(p_vz * p_z * t0.VScaleFactor);
 
 					Vec8i tu = packed_tile_u(u, t0.LogHeight, t0_umask_swizzled);
 					Vec8i tv = packed_tile_v(v, t0_vmask);
@@ -250,8 +285,8 @@ struct TileRasterizer {
 
 					auto texture0_samples = gather(Vec8ui(p_offset), t0.TextureAddr, p_mask);
 					if constexpr (TextureMode == barry::TTextureMode::TEXTURETEXTURE) {
-						Vec8i u1 = roundi(p_u1z * p_z * 1024.0f);
-						Vec8i v1 = roundi(p_v1z * p_z * 1024.0f);
+						Vec8i u1 = compat_roundi(p_u1z * p_z * 1024.0f);
+						Vec8i v1 = compat_roundi(p_v1z * p_z * 1024.0f);
 
 						Vec8i tu1 = packed_tile_u(u1, 10, t1_umask_swizzled);
 						Vec8i tv1 = packed_tile_v(v1, t1_vmask);

--- a/FDS/FILLERS/TheOtherBarry.h
+++ b/FDS/FILLERS/TheOtherBarry.h
@@ -81,37 +81,28 @@ inline TScreenCoord orient2d(
 	return (int64_t(bx - ax) * int64_t(cy - ay) - int64_t(by - ay) * int64_t(cx - ax)) >> SUBPIXEL_BITS;
 }
 
-// On wasm, simde maps _mm_rcp_ps / _mm256_rcp_ps to wasm_f32x4_div(1, x) —
-// full IEEE precision. The rasterizer's perspective-correct mapping was
-// tuned for the ~12-bit approximate reciprocal that x86 (RCPPS) and arm64
-// (vrecpeq_f32) produce; the extra precision lands UVs exactly on texel
-// boundaries where the float-to-int convert flips, producing 1-pixel
-// perspective seam artifacts. Bit-trick initial estimate + 1 Newton-Raphson
-// step gives matching ~12-bit precision on wasm. Other targets keep the
-// native path.
+// Native (x86 RCPPS, arm64 vrecpeq_f32) and wasm (simde → exact 1/x) all
+// produce *different* bit patterns even at similar nominal precision.
+// The rasterizer's per-tile UV chain is sensitive enough that those
+// differences flip Z-test outcomes at polygon edges and shift point-
+// sampled texel lookups by 1 — visible as polygon seams native-side and
+// black speckle / heavier divergence wasm-side. Use a deterministic
+// bit-trick + 1 Newton-Raphson step on every target so all builds compute
+// the same ~12-bit approximate reciprocal.
 inline Vec8f compat_approx_recipr(Vec8f a) {
-#if defined(__EMSCRIPTEN__)
 	Vec8i ai = _mm256_castps_si256(a);
 	Vec8i mi = Vec8i(0x7EF311C3) - ai;
 	Vec8f y = _mm256_castsi256_ps(mi);
 	return y * (Vec8f(2.0f) - a * y);
-#else
-	return approx_recipr(a);
-#endif
 }
 
-// On wasm, _mm256_cvtps_epi32 → simde → nearbyintf which uses the C-library
-// rounding mode (round-to-nearest-even on wasm, with no way to change it).
-// On x86/arm64 the same call respects the ROUND_UP mode that FPU_LPrecision()
-// sets, biasing UV conversions slightly upward — the rasterizer's texel
-// addressing depends on that bias. Emulate ROUND_UP via explicit ceil before
-// convert so values land on the same texel as the native build.
+// The rasterizer's texel addressing was tuned for ROUND_UP at the float→int
+// step. Native (x86 MXCSR / arm64 FPCR) gets that via FPU_LPrecision(); wasm
+// has no rounding-mode register, so we have to emulate. Use explicit ceil
+// before the convert on every target so the rasterizer behaves identically
+// regardless of FPCR — no implicit dependency on the host rounding mode.
 inline Vec8i compat_roundi(Vec8f a) {
-#if defined(__EMSCRIPTEN__)
 	return _mm256_cvtps_epi32(_mm256_ceil_ps(a));
-#else
-	return roundi(a);
-#endif
 }
 
 // block-tiling adjustment functions

--- a/FDS/FILLERS/TheOtherBarry.h
+++ b/FDS/FILLERS/TheOtherBarry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 
 #include "Base/FDS_DECS.H"
 #include "F4Vec.h"
@@ -327,12 +328,18 @@ struct TileRasterizer {
 		const int tile_my = clampedY(std::min({ v1.PY, v2.PY, v3.PY })) / TILE_SIZE;
 		const int tile_My = clampedY(std::max({ v1.PY, v2.PY, v3.PY })) / TILE_SIZE;
 
-		TScreenCoord v1x = TScreenCoord(v1.PX * SUBPIXEL_MULT + 0.5);
-		TScreenCoord v1y = TScreenCoord(v1.PY * SUBPIXEL_MULT + 0.5);
-		TScreenCoord v2x = TScreenCoord(v2.PX * SUBPIXEL_MULT + 0.5);
-		TScreenCoord v2y = TScreenCoord(v2.PY * SUBPIXEL_MULT + 0.5);
-		TScreenCoord v3x = TScreenCoord(v3.PX * SUBPIXEL_MULT + 0.5);
-		TScreenCoord v3y = TScreenCoord(v3.PY * SUBPIXEL_MULT + 0.5);
+		// std::lroundf does round-half-away-from-zero in software, ignoring
+		// the FPU rounding mode. The float `v.PX * SUBPIXEL_MULT` step is
+		// still subject to FPCR on native (ROUND_UP) vs RTNE on wasm, but
+		// doing the *round* in lroundf instead of `int(x + 0.5)` makes the
+		// conversion stable even when the multiplication lands exactly on a
+		// half-integer.
+		TScreenCoord v1x = TScreenCoord(std::lroundf(v1.PX * SUBPIXEL_MULT));
+		TScreenCoord v1y = TScreenCoord(std::lroundf(v1.PY * SUBPIXEL_MULT));
+		TScreenCoord v2x = TScreenCoord(std::lroundf(v2.PX * SUBPIXEL_MULT));
+		TScreenCoord v2y = TScreenCoord(std::lroundf(v2.PY * SUBPIXEL_MULT));
+		TScreenCoord v3x = TScreenCoord(std::lroundf(v3.PX * SUBPIXEL_MULT));
+		TScreenCoord v3y = TScreenCoord(std::lroundf(v3.PY * SUBPIXEL_MULT));
 
 		TScreenCoord x0 = tile_mx * TILE_SIZE << SUBPIXEL_BITS;
 		TScreenCoord y0 = tile_my * TILE_SIZE << SUBPIXEL_BITS;

--- a/FDS/FILLERS/TheOtherBarry.h
+++ b/FDS/FILLERS/TheOtherBarry.h
@@ -103,14 +103,12 @@ inline Vec8f compat_approx_recipr(Vec8f a) {
 // On wasm, _mm256_cvtps_epi32 → simde → nearbyintf which uses the C-library
 // rounding mode (round-to-nearest-even on wasm, with no way to change it).
 // On x86/arm64 the same call respects the ROUND_UP mode that FPU_LPrecision()
-// sets, biasing UV/Z conversions slightly upward. Beyond the convert itself,
-// every preceding FP add/mul on x86/arm64 also rounds up by ~1 ULP, so by
-// the time a value reaches the convert it's accumulated a small upward bias.
-// Emulate that on wasm via ceil-after-tiny-relative-nudge so values that
-// would land exactly on integer boundaries pop to the same texel as macOS.
+// sets, biasing UV conversions slightly upward — the rasterizer's texel
+// addressing depends on that bias. Emulate ROUND_UP via explicit ceil before
+// convert so values land on the same texel as the native build.
 inline Vec8i compat_roundi(Vec8f a) {
 #if defined(__EMSCRIPTEN__)
-	return _mm256_cvtps_epi32(_mm256_ceil_ps(a * Vec8f(1.0f + 1.0e-5f)));
+	return _mm256_cvtps_epi32(_mm256_ceil_ps(a));
 #else
 	return roundi(a);
 #endif

--- a/tools/snapshot_diff.py
+++ b/tools/snapshot_diff.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Compare two snapshot PPMs and emit a diff image + numeric summary.
+
+Usage:
+    tools/snapshot_diff.py <a.ppm> <b.ppm> [<diff.png>]
+
+The diff image highlights where pixels differ. A red overlay marks pixels
+that disagree at all; brightness scales with the channel-summed absolute
+difference. White pixels mean ~equal.
+"""
+import sys
+from PIL import Image, ImageChops, ImageFilter
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(2)
+    a_path, b_path = sys.argv[1], sys.argv[2]
+    out_path = sys.argv[3] if len(sys.argv) > 3 else None
+
+    a = Image.open(a_path).convert("RGB")
+    b = Image.open(b_path).convert("RGB")
+    if a.size != b.size:
+        print(f"size mismatch: {a.size} vs {b.size}", file=sys.stderr)
+        sys.exit(1)
+
+    diff = ImageChops.difference(a, b)
+    diff_pixels = diff.load()
+    w, h = diff.size
+
+    differing = 0
+    max_per_channel = 0
+    sum_abs = 0
+    for y in range(h):
+        for x in range(w):
+            r, g, b_ = diff_pixels[x, y]
+            s = r + g + b_
+            if s > 0:
+                differing += 1
+                sum_abs += s
+                if max(r, g, b_) > max_per_channel:
+                    max_per_channel = max(r, g, b_)
+    total = w * h
+    pct = 100.0 * differing / total
+    avg = sum_abs / max(differing, 1)
+    print(f"{a_path}  vs  {b_path}")
+    print(f"  size:           {w}x{h} = {total} px")
+    print(f"  differing px:   {differing} ({pct:.3f}%)")
+    print(f"  max channel Δ:  {max_per_channel}/255")
+    print(f"  mean Δ-sum/diff:{avg:.2f} (out of 765 max)")
+
+    if out_path:
+        # Boost diff for visibility: clamp(diff*8) plus a pure-red mask of
+        # any-difference pixels overlaid on the dimmed left input.
+        boosted = Image.eval(diff, lambda v: min(v * 8, 255))
+        base = Image.eval(a, lambda v: v // 3)
+        mask = boosted.convert("L").point(lambda v: 255 if v > 0 else 0)
+        red = Image.new("RGB", (w, h), (255, 0, 0))
+        out = Image.composite(red, base, mask)
+        out.save(out_path)
+        print(f"  wrote diff:     {out_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Two unrelated wasm-only bugs.

### Rasterizer texture seams (partial)
The active rasterizer (\`TheOtherBarry::apply_exact\`, also \`Mekalele\`) calls vectorclass \`approx_recipr\` and \`roundi\`. simde maps both to *exact* operations on wasm but to ~12-bit approximate / MXCSR-respecting on x86 + arm64. The 1998 perspective-correct UV math was tuned around the approximate-reciprocal precision and the upward bias from \`FPU_LPrecision()\`'s \`ROUND_UP\` MXCSR/FPCR setting; on wasm those biases vanish and UVs land on texel boundaries that flip during float-to-int conversion → diagonal seams across textured surfaces.

Fix: \`compat_approx_recipr\` (bit-trick + 1 Newton step, ~12-bit) and \`compat_roundi\` (ceil before convert) under \`__EMSCRIPTEN__\`. Native paths unchanged.

**Known limitation**: this covers the *final* convert step, the dominant error source. Per-step ULP drift in the FP arithmetic upstream is irrecoverable on wasm — there's no rounding-mode register, so we can't apply ROUND_UP to every \`+\`/\`*\`. A small fraction of pixels (visible as sparse 1-pixel dots near polygon edges) still flips to a different texel. Fully eliminating this would require a rounding-mode-independent rasterizer (non-trivial; would touch the macOS path).

### SDL → legacy scancode mapping
\`FDS_DEFS.H\` \`ScXxx\` constants are PS/2 set-1 scancodes inherited from the DOS build. SDL2 reports USB-HID scancodes which differ for almost everything (\`SDL_SCANCODE_P=19\` ≠ \`ScP=25\`, \`SDL_SCANCODE_TAB=43\` ≠ \`ScTab=15\`, ...). Only \`ScESC\` (41) coincided with \`SDL_SCANCODE_ESCAPE\` — that's why exit worked but pause / camera switch / arrows did not.

Fix: translate SDL → legacy in the event loop. Also \`preventDefault\` on keys the browser swallows (Tab focus-nav, function keys, arrows, space).

## Test plan
- [x] City scene textures: dense seam pattern eliminated (was uniform diagonal streaks across all walls)
- [x] Residual sparse 1-pixel artifacts at some polygon edges (documented limitation above)
- [x] P toggles pause, U unpauses
- [x] Tab switches camera
- [x] Native macOS build unchanged (helpers fall through to vectorclass on non-emscripten)

## Known follow-ups
- Glat animation drifts on wasm. Likely \`SDL_AddTimer\` throttling on emscripten — Timer doesn't tick at exactly 100Hz. Separate fix.
- \`Modplayer_SetOrder\` doesn't release currently-playing voices when scenes jump tracks. Needs xmplayer-side change (no \"kill all notes\" command in \`PlaybackCmd\`). Separate fix.